### PR TITLE
fix(speech): 録音開始時の再初期化と再試行を追加

### DIFF
--- a/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
+++ b/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
@@ -14,6 +14,11 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
   }
 
   private initRecognition(): void {
+    if (typeof window === 'undefined') {
+      this.status = 'error'
+      return
+    }
+
     const SpeechRecognition =
       (window as any).SpeechRecognition ||
       (window as any).webkitSpeechRecognition
@@ -27,6 +32,12 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
     recognition.continuous = true
     recognition.interimResults = true
     recognition.lang = 'ja-JP'
+
+    recognition.onstart = () => {
+      this.isRunning = true
+      this.status = 'listening'
+      this.notify()
+    }
 
     recognition.onresult = (event: any) => {
       let current = ''
@@ -62,14 +73,33 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
   }
 
   startListening(): void {
-    if (!this.recognition || this.isRunning) return
+    if (this.isRunning) return
+    if (!this.recognition) this.initRecognition()
+    if (!this.recognition) {
+      this.status = 'error'
+      this.notify()
+      return
+    }
+
     this.status = 'listening'
     this.isRunning = true
     try {
       this.recognition.start()
     } catch {
-      this.status = 'error'
-      this.isRunning = false
+      // ブラウザ状態で start() が失敗するケースがあるため、1回だけ再初期化して再試行する。
+      this.initRecognition()
+      if (!this.recognition) {
+        this.status = 'error'
+        this.isRunning = false
+        this.notify()
+        return
+      }
+      try {
+        this.recognition.start()
+      } catch {
+        this.status = 'error'
+        this.isRunning = false
+      }
     }
     this.notify()
   }


### PR DESCRIPTION
## 対応内容
- `WebSpeechTranscriptionService` の `startListening()` を強化
  - recognition 未初期化時に `initRecognition()` を実行
  - `recognition.start()` 失敗時に **再初期化 + 1回だけ再試行**
- `recognition.onstart` を追加し、実際の開始タイミングで `status=listening` / `isRunning=true` を同期
- `window` 未定義環境向けのガードを追加

## 期待される効果
- 録音開始ボタン押下で、マイク録音と文字起こし開始まで到達しやすくなる
- 一時的な `start()` 失敗から復帰できるようになる

## 変更ファイル
- `Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts`