### PR TITLE
feat(frontend): 文字起こし精度・検証まわりの改善

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -1,6 +1,12 @@
 # ベクトルAPI（開発時プロキシ先）
 VITE_BACKEND_URL=http://127.0.0.1:8000
 
+# 文字起こしの初期モード（fast: 速度重視 / accurate: 正確さ重視）
+VITE_TRANSCRIPTION_MODE_DEFAULT=fast
+
+# accurate モード時に使うローカルSTTサーバー
+VITE_LOCAL_STT_URL=http://127.0.0.1:8765/transcribe
+
 # 前回送信とかぶらせる文の数（未設定時は 5）
 VITE_VECTOR_OVERLAP_SENTENCES=5
 

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test:local-server": "node tests/local-server/transcriptReceiver.mjs",
     "verify:similarity": "bun run src/app/utils/verifySimilarity.ts"
   },
   "dependencies": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test:local-server": "node tests/local-server/transcriptReceiver.mjs",
+    "test:local-stt-server": "cd tests/local-stt && uvicorn server:app --host 127.0.0.1 --port 8765",
     "verify:similarity": "bun run src/app/utils/verifySimilarity.ts"
   },
   "dependencies": {

--- a/Frontend/src/app/components/TranscriptionView.tsx
+++ b/Frontend/src/app/components/TranscriptionView.tsx
@@ -5,6 +5,7 @@ import { Term } from '../data/terms';
 import { motion, AnimatePresence } from 'motion/react';
 import { Mic, Square, Radio, Play, RotateCcw, FastForward, Pause, LoaderCircle, Star } from 'lucide-react';
 import { UseDemoStreamReturn } from '../../debug/hooks/useDemoStream';
+import type { MicrophoneDevice } from '../../domain/interfaces/ITranscriptionService';
 
 const TOOLTIP = { W: 208, H: 100, PAD: 8, GAP_ABOVE: 12 } as const;
 
@@ -12,6 +13,10 @@ interface TranscriptionViewProps {
   transcript: string;
   isListening: boolean;
   onToggleListening: () => void;
+  microphones?: MicrophoneDevice[];
+  selectedMicrophoneId?: string;
+  onSelectMicrophone?: (deviceId: string) => void;
+  onRefreshMicrophones?: () => void;
   onClearTranscript?: () => void;
   onTermClick: (term: Term) => void;
   onTermHover: (term: Term | null) => void;
@@ -33,6 +38,10 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
   transcript,
   isListening,
   onToggleListening,
+  microphones = [],
+  selectedMicrophoneId = '',
+  onSelectMicrophone,
+  onRefreshMicrophones,
   onClearTranscript,
   onTermClick,
   onTermHover,
@@ -329,6 +338,38 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
             <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
               {isListening ? '中断' : '録音開始'}
             </span>
+            <div className="mt-1 flex items-center gap-1.5">
+              <select
+                value={selectedMicrophoneId}
+                onChange={(e) => onSelectMicrophone?.(e.target.value)}
+                className={`max-w-[180px] rounded-md border px-2 py-1 text-[10px] ${
+                  dk
+                    ? 'bg-slate-800 border-slate-700 text-slate-200'
+                    : 'bg-white border-slate-300 text-slate-700'
+                }`}
+                title="使用するマイクを選択"
+              >
+                {microphones.length === 0 && (
+                  <option value="">利用可能マイクなし</option>
+                )}
+                {microphones.map((mic) => (
+                  <option key={mic.deviceId} value={mic.deviceId}>
+                    {mic.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={onRefreshMicrophones}
+                className={`rounded-md border px-2 py-1 text-[10px] font-bold ${
+                  dk
+                    ? 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700'
+                    : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+                }`}
+                title="マイク一覧を再取得"
+              >
+                更新
+              </button>
+            </div>
           </div>
 
           {/* ライブデモボタン＋速度スライダー（右側） */}

--- a/Frontend/src/app/components/TranscriptionView.tsx
+++ b/Frontend/src/app/components/TranscriptionView.tsx
@@ -5,7 +5,7 @@ import { Term } from '../data/terms';
 import { motion, AnimatePresence } from 'motion/react';
 import { Mic, Square, Radio, Play, RotateCcw, FastForward, Pause, LoaderCircle, Star } from 'lucide-react';
 import { UseDemoStreamReturn } from '../../debug/hooks/useDemoStream';
-import type { MicrophoneDevice } from '../../domain/interfaces/ITranscriptionService';
+import type { MicrophoneDevice, TranscriptionMode } from '../../domain/interfaces/ITranscriptionService';
 
 const TOOLTIP = { W: 208, H: 100, PAD: 8, GAP_ABOVE: 12 } as const;
 
@@ -13,6 +13,8 @@ interface TranscriptionViewProps {
   transcript: string;
   isListening: boolean;
   onToggleListening: () => void;
+  mode?: TranscriptionMode;
+  onChangeMode?: (mode: TranscriptionMode) => void;
   microphones?: MicrophoneDevice[];
   selectedMicrophoneId?: string;
   onSelectMicrophone?: (deviceId: string) => void;
@@ -38,6 +40,8 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
   transcript,
   isListening,
   onToggleListening,
+  mode = 'fast',
+  onChangeMode,
   microphones = [],
   selectedMicrophoneId = '',
   onSelectMicrophone,
@@ -337,6 +341,25 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
             </AnimatePresence>
             <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
               {isListening ? '中断' : '録音開始'}
+            </span>
+            <div className="mt-1 flex items-center gap-1.5">
+              <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>モード</span>
+              <select
+                value={mode}
+                onChange={(e) => onChangeMode?.(e.target.value as TranscriptionMode)}
+                className={`rounded-md border px-2 py-1 text-[10px] ${
+                  dk
+                    ? 'bg-slate-800 border-slate-700 text-slate-200'
+                    : 'bg-white border-slate-300 text-slate-700'
+                }`}
+                title="文字起こしモードを選択"
+              >
+                <option value="fast">速度重視</option>
+                <option value="accurate">正確さ重視</option>
+              </select>
+            </div>
+            <span className={`text-[9px] ${dk ? 'text-slate-600' : 'text-slate-400'}`}>
+              {mode === 'fast' ? 'WebSpeechでリアルタイム寄り' : '停止後にローカルSTTで高精度化'}
             </span>
             <div className="mt-1 flex items-center gap-1.5">
               <select

--- a/Frontend/src/domain/interfaces/ITranscriptionService.ts
+++ b/Frontend/src/domain/interfaces/ITranscriptionService.ts
@@ -1,4 +1,5 @@
 export type TranscriptionStatus = 'idle' | 'listening' | 'error'
+export type TranscriptionMode = 'fast' | 'accurate'
 export type MicrophoneDevice = {
   deviceId: string
   label: string

--- a/Frontend/src/domain/interfaces/ITranscriptionService.ts
+++ b/Frontend/src/domain/interfaces/ITranscriptionService.ts
@@ -1,10 +1,18 @@
 export type TranscriptionStatus = 'idle' | 'listening' | 'error'
+export type MicrophoneDevice = {
+  deviceId: string
+  label: string
+}
 
 export interface ITranscriptionService {
   getStatus(): TranscriptionStatus
   getTranscript(): string
   startListening(): void
   stopListening(): void
+  getAvailableMicrophones(): MicrophoneDevice[]
+  getSelectedMicrophoneId(): string
+  setSelectedMicrophone(deviceId: string): void
+  refreshMicrophones(): Promise<void>
   clearTranscript(): void
   /** デモ・テスト用に全文を差し替え（音声入力とは独立） */
   setTranscriptExternal(text: string): void

--- a/Frontend/src/infrastructure/speech/LocalSttTranscriptionService.ts
+++ b/Frontend/src/infrastructure/speech/LocalSttTranscriptionService.ts
@@ -1,0 +1,211 @@
+import type { ITranscriptionService, MicrophoneDevice, TranscriptionStatus } from '../../domain/interfaces/ITranscriptionService'
+
+type ChangeHandler = () => void
+
+const DEFAULT_LOCAL_STT_URL = 'http://127.0.0.1:8765/transcribe'
+
+export class LocalSttTranscriptionService implements ITranscriptionService {
+  private transcript = ''
+  private status: TranscriptionStatus = 'idle'
+  private isRunning = false
+  private microphones: MicrophoneDevice[] = []
+  private selectedMicrophoneId = ''
+  private selectedMicStream: MediaStream | null = null
+  private recorder: MediaRecorder | null = null
+  private chunks: Blob[] = []
+  private listeners = new Set<ChangeHandler>()
+
+  constructor() {
+    void this.refreshMicrophones()
+  }
+
+  private getLocalSttUrl(): string {
+    const raw = import.meta.env.VITE_LOCAL_STT_URL
+    const trimmed = typeof raw === 'string' ? raw.trim() : ''
+    return trimmed || DEFAULT_LOCAL_STT_URL
+  }
+
+  private getRecorderMimeType(): string | undefined {
+    if (typeof MediaRecorder === 'undefined') return undefined
+    const candidates = [
+      'audio/webm;codecs=opus',
+      'audio/webm',
+      'audio/mp4',
+    ]
+    return candidates.find((t) => MediaRecorder.isTypeSupported(t))
+  }
+
+  getStatus(): TranscriptionStatus {
+    return this.status
+  }
+
+  getTranscript(): string {
+    return this.transcript
+  }
+
+  getAvailableMicrophones(): MicrophoneDevice[] {
+    return this.microphones
+  }
+
+  getSelectedMicrophoneId(): string {
+    return this.selectedMicrophoneId
+  }
+
+  setSelectedMicrophone(deviceId: string): void {
+    this.selectedMicrophoneId = deviceId
+    this.notify()
+  }
+
+  async refreshMicrophones(): Promise<void> {
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.enumerateDevices) {
+      this.microphones = []
+      this.selectedMicrophoneId = ''
+      this.notify()
+      return
+    }
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices()
+      const audioInputs = devices
+        .filter(d => d.kind === 'audioinput')
+        .map((d, i) => ({
+          deviceId: d.deviceId,
+          label: d.label || `マイク ${i + 1}`,
+        }))
+      this.microphones = audioInputs
+      if (!audioInputs.some(d => d.deviceId === this.selectedMicrophoneId)) {
+        this.selectedMicrophoneId = audioInputs[0]?.deviceId ?? ''
+      }
+      this.notify()
+    } catch {
+      this.microphones = []
+      this.selectedMicrophoneId = ''
+      this.notify()
+    }
+  }
+
+  startListening(): void {
+    if (this.isRunning) return
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      this.status = 'error'
+      this.notify()
+      return
+    }
+    if (typeof MediaRecorder === 'undefined') {
+      this.status = 'error'
+      this.notify()
+      return
+    }
+
+    this.status = 'listening'
+    this.isRunning = true
+    this.chunks = []
+    this.notify()
+
+    void (async () => {
+      try {
+        const constraints = this.selectedMicrophoneId
+          ? { audio: { deviceId: { exact: this.selectedMicrophoneId } } }
+          : { audio: true }
+        const stream = await navigator.mediaDevices.getUserMedia(constraints)
+        this.selectedMicStream?.getTracks().forEach(track => track.stop())
+        this.selectedMicStream = stream
+
+        const mimeType = this.getRecorderMimeType()
+        this.recorder = mimeType
+          ? new MediaRecorder(stream, { mimeType })
+          : new MediaRecorder(stream)
+
+        this.recorder.ondataavailable = (event: BlobEvent) => {
+          if (event.data.size > 0) this.chunks.push(event.data)
+        }
+        this.recorder.onerror = () => {
+          this.status = 'error'
+          this.isRunning = false
+          this.releaseResources()
+          this.notify()
+        }
+        this.recorder.onstop = () => {
+          void this.transcribeRecordedAudio()
+        }
+        this.recorder.start()
+      } catch (err) {
+        if (import.meta.env.DEV) console.warn('[local-stt] start failed', err)
+        this.status = 'error'
+        this.isRunning = false
+        this.releaseResources()
+        this.notify()
+      }
+    })()
+  }
+
+  stopListening(): void {
+    if (!this.isRunning) return
+    this.isRunning = false
+    this.status = 'idle'
+    this.notify()
+    try {
+      this.recorder?.stop()
+    } catch {
+      this.releaseResources()
+    }
+  }
+
+  clearTranscript(): void {
+    this.transcript = ''
+    this.notify()
+  }
+
+  setTranscriptExternal(text: string): void {
+    this.transcript = text
+    this.notify()
+  }
+
+  subscribe(handler: ChangeHandler): () => void {
+    this.listeners.add(handler)
+    return () => this.listeners.delete(handler)
+  }
+
+  private async transcribeRecordedAudio(): Promise<void> {
+    const blob = new Blob(this.chunks, { type: this.recorder?.mimeType || 'audio/webm' })
+    this.releaseResources()
+    this.chunks = []
+    if (blob.size === 0) return
+
+    const formData = new FormData()
+    formData.append('file', blob, 'recording.webm')
+    formData.append('language', 'ja')
+
+    try {
+      const res = await fetch(this.getLocalSttUrl(), {
+        method: 'POST',
+        body: formData,
+      })
+      if (!res.ok) {
+        if (import.meta.env.DEV) {
+          console.warn('[local-stt] transcribe failed', res.status, await res.text())
+        }
+        this.status = 'error'
+        this.notify()
+        return
+      }
+      const data = await res.json() as { text?: string }
+      this.transcript = (data.text ?? '').trim()
+      this.notify()
+    } catch (err) {
+      if (import.meta.env.DEV) console.warn('[local-stt] request failed', err)
+      this.status = 'error'
+      this.notify()
+    }
+  }
+
+  private releaseResources(): void {
+    this.recorder = null
+    this.selectedMicStream?.getTracks().forEach(track => track.stop())
+    this.selectedMicStream = null
+  }
+
+  private notify(): void {
+    this.listeners.forEach(fn => fn())
+  }
+}
+

--- a/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
+++ b/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
@@ -13,6 +13,9 @@ const DEFAULT_UPLOAD_MODE: TranscriptUploadMode = 'disabled'
 
 export class WebSpeechTranscriptionService implements ITranscriptionService {
   private transcript = ''
+  private finalTranscript = ''
+  private interimTranscript = ''
+  private finalizedResultIndices = new Set<number>()
   private status: TranscriptionStatus = 'idle'
   private recognition: any = null
   private isRunning = false
@@ -49,12 +52,32 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
     }
 
     recognition.onresult = (event: any) => {
-      let current = ''
-      for (let i = 0; i < event.results.length; i++) {
-        const text: string = event.results[i][0].transcript
-        current += event.results[i].isFinal ? text + '。\n' : text
+      let nextInterim = ''
+      const start = typeof event.resultIndex === 'number' ? event.resultIndex : 0
+
+      for (let i = start; i < event.results.length; i++) {
+        const result = event.results[i]
+        const text: string = result?.[0]?.transcript ?? ''
+        const normalized = text.trim()
+        if (!normalized) continue
+
+        if (result.isFinal) {
+          // 同じ result index の確定文を重複追加しない
+          if (!this.finalizedResultIndices.has(i)) {
+            this.finalTranscript += `${normalized}。\n`
+            this.finalizedResultIndices.add(i)
+          }
+        } else {
+          nextInterim += text
+        }
       }
-      this.transcript = current
+
+      // 不正確でも文字を残したい要件のため、途中文字列が短くなる更新では縮めない
+      const nextInterimTrimmed = nextInterim.trim()
+      if (nextInterimTrimmed.length >= this.interimTranscript.trim().length) {
+        this.interimTranscript = nextInterim
+      }
+      this.transcript = `${this.finalTranscript}${this.interimTranscript}`
       this.notify()
     }
 
@@ -178,11 +201,17 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
 
   clearTranscript(): void {
     this.transcript = ''
+    this.finalTranscript = ''
+    this.interimTranscript = ''
+    this.finalizedResultIndices.clear()
     this.notify()
   }
 
   setTranscriptExternal(text: string): void {
     this.transcript = text
+    this.finalTranscript = text
+    this.interimTranscript = ''
+    this.finalizedResultIndices.clear()
     this.notify()
   }
 

--- a/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
+++ b/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
@@ -1,6 +1,15 @@
 import type { ITranscriptionService, TranscriptionStatus } from '../../domain/interfaces/ITranscriptionService'
 
 type ChangeHandler = () => void
+type TranscriptUploadMode = 'disabled' | 'local' | 'remote'
+type UploadTranscriptPayload = {
+  transcript: string
+  language: string
+  recordedAt: string
+}
+
+const DEFAULT_TRANSCRIPT_UPLOAD_URL = 'http://localhost:8000/transcript'
+const DEFAULT_UPLOAD_MODE: TranscriptUploadMode = 'disabled'
 
 export class WebSpeechTranscriptionService implements ITranscriptionService {
   private transcript = ''
@@ -64,6 +73,60 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
     this.recognition = recognition
   }
 
+  private getUploadUrl(): string {
+    const raw = import.meta.env.VITE_TRANSCRIPT_UPLOAD_URL
+    const trimmed = typeof raw === 'string' ? raw.trim() : ''
+    return trimmed || DEFAULT_TRANSCRIPT_UPLOAD_URL
+  }
+
+  private getUploadMode(): TranscriptUploadMode {
+    const raw = import.meta.env.VITE_TRANSCRIPT_UPLOAD_MODE
+    const mode = typeof raw === 'string' ? raw.trim().toLowerCase() : ''
+    if (mode === 'local' || mode === 'remote' || mode === 'disabled') {
+      return mode
+    }
+    return DEFAULT_UPLOAD_MODE
+  }
+
+  private buildUploadPayload(): UploadTranscriptPayload | null {
+    const text = this.transcript.trim()
+    if (!text) return null
+    return {
+      transcript: text,
+      language: 'ja-JP',
+      recordedAt: new Date().toISOString(),
+    }
+  }
+
+  private async uploadTranscript(): Promise<void> {
+    const mode = this.getUploadMode()
+    if (mode === 'disabled') {
+      if (import.meta.env.DEV) {
+        console.log('[transcription] upload skipped (mode=disabled)')
+      }
+      return
+    }
+    const payload = this.buildUploadPayload()
+    if (!payload) return
+    const url = this.getUploadUrl()
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok && import.meta.env.DEV) {
+        console.warn('[transcription] upload failed', res.status, await res.text())
+      } else if (import.meta.env.DEV) {
+        console.log(`[transcription] upload success (mode=${mode})`, url)
+      }
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn('[transcription] upload error', error)
+      }
+    }
+  }
+
   getStatus(): TranscriptionStatus {
     return this.status
   }
@@ -109,6 +172,7 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
     this.isRunning = false
     this.status = 'idle'
     try { this.recognition.stop() } catch { /* ignore */ }
+    void this.uploadTranscript()
     this.notify()
   }
 

--- a/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
+++ b/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
@@ -1,4 +1,4 @@
-import type { ITranscriptionService, TranscriptionStatus } from '../../domain/interfaces/ITranscriptionService'
+import type { ITranscriptionService, MicrophoneDevice, TranscriptionStatus } from '../../domain/interfaces/ITranscriptionService'
 
 type ChangeHandler = () => void
 type TranscriptUploadMode = 'disabled' | 'local' | 'remote'
@@ -19,10 +19,14 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
   private status: TranscriptionStatus = 'idle'
   private recognition: any = null
   private isRunning = false
+  private microphones: MicrophoneDevice[] = []
+  private selectedMicrophoneId = ''
+  private selectedMicStream: MediaStream | null = null
   private listeners = new Set<ChangeHandler>()
 
   constructor() {
     this.initRecognition()
+    void this.refreshMicrophones()
   }
 
   private initRecognition(): void {
@@ -150,6 +154,65 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
     }
   }
 
+  getAvailableMicrophones(): MicrophoneDevice[] {
+    return this.microphones
+  }
+
+  getSelectedMicrophoneId(): string {
+    return this.selectedMicrophoneId
+  }
+
+  setSelectedMicrophone(deviceId: string): void {
+    this.selectedMicrophoneId = deviceId
+    this.notify()
+  }
+
+  async refreshMicrophones(): Promise<void> {
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.enumerateDevices) {
+      this.microphones = []
+      this.selectedMicrophoneId = ''
+      this.notify()
+      return
+    }
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices()
+      const audioInputs = devices
+        .filter(d => d.kind === 'audioinput')
+        .map((d, i) => ({
+          deviceId: d.deviceId,
+          label: d.label || `マイク ${i + 1}`,
+        }))
+      this.microphones = audioInputs
+      if (!audioInputs.some(d => d.deviceId === this.selectedMicrophoneId)) {
+        this.selectedMicrophoneId = audioInputs[0]?.deviceId ?? ''
+      }
+      this.notify()
+    } catch {
+      this.microphones = []
+      this.selectedMicrophoneId = ''
+      this.notify()
+    }
+  }
+
+  private async prepareSelectedMicrophone(): Promise<void> {
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) return
+    if (!this.selectedMicrophoneId) return
+    try {
+      this.selectedMicStream?.getTracks().forEach(track => track.stop())
+      this.selectedMicStream = await navigator.mediaDevices.getUserMedia({
+        audio: { deviceId: { exact: this.selectedMicrophoneId } },
+      })
+      await this.refreshMicrophones()
+    } catch (err) {
+      if (import.meta.env.DEV) console.warn('[transcription] selected mic prepare failed', err)
+    }
+  }
+
+  private releaseSelectedMicrophone(): void {
+    this.selectedMicStream?.getTracks().forEach(track => track.stop())
+    this.selectedMicStream = null
+  }
+
   getStatus(): TranscriptionStatus {
     return this.status
   }
@@ -169,6 +232,7 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
 
     this.status = 'listening'
     this.isRunning = true
+    void this.prepareSelectedMicrophone()
     try {
       this.recognition.start()
     } catch {
@@ -195,6 +259,7 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
     this.isRunning = false
     this.status = 'idle'
     try { this.recognition.stop() } catch { /* ignore */ }
+    this.releaseSelectedMicrophone()
     void this.uploadTranscript()
     this.notify()
   }

--- a/Frontend/src/presentation/hooks/useTranscription.ts
+++ b/Frontend/src/presentation/hooks/useTranscription.ts
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { WebSpeechTranscriptionService } from '../../infrastructure/speech/WebSpeechTranscriptionService'
 import { useTranscriptStore } from '../../stores/transcriptStore'
+import type { MicrophoneDevice } from '../../domain/interfaces/ITranscriptionService'
 
 // シングルトンサービス（アプリ全体で一つ）
 let _service: WebSpeechTranscriptionService | null = null
@@ -17,12 +18,17 @@ export function useTranscription() {
   const transcript = useTranscriptStore(s => s.transcript)
   const status = useTranscriptStore(s => s.status)
   const serviceRef = useRef(getTranscriptionService())
+  const [microphones, setMicrophones] = useState<MicrophoneDevice[]>(serviceRef.current.getAvailableMicrophones())
+  const [selectedMicrophoneId, setSelectedMicrophoneId] = useState(serviceRef.current.getSelectedMicrophoneId())
 
   useEffect(() => {
     const service = serviceRef.current
+    void service.refreshMicrophones()
     const unsubscribe = service.subscribe(() => {
       setTranscript(service.getTranscript())
       setStatus(service.getStatus())
+      setMicrophones(service.getAvailableMicrophones())
+      setSelectedMicrophoneId(service.getSelectedMicrophoneId())
     })
     return unsubscribe
   }, [setTranscript, setStatus])
@@ -31,6 +37,10 @@ export function useTranscription() {
     transcript,
     status,
     isListening: status === 'listening',
+    microphones,
+    selectedMicrophoneId,
+    refreshMicrophones: () => serviceRef.current.refreshMicrophones(),
+    selectMicrophone: (deviceId: string) => serviceRef.current.setSelectedMicrophone(deviceId),
     startListening: () => serviceRef.current.startListening(),
     stopListening: () => serviceRef.current.stopListening(),
     clearTranscript: () => {

--- a/Frontend/src/presentation/hooks/useTranscription.ts
+++ b/Frontend/src/presentation/hooks/useTranscription.ts
@@ -1,15 +1,39 @@
 import { useEffect, useRef, useState } from 'react'
 import { WebSpeechTranscriptionService } from '../../infrastructure/speech/WebSpeechTranscriptionService'
+import { LocalSttTranscriptionService } from '../../infrastructure/speech/LocalSttTranscriptionService'
 import { useTranscriptStore } from '../../stores/transcriptStore'
-import type { MicrophoneDevice } from '../../domain/interfaces/ITranscriptionService'
+import type { ITranscriptionService, MicrophoneDevice, TranscriptionMode } from '../../domain/interfaces/ITranscriptionService'
 
-// シングルトンサービス（アプリ全体で一つ）
-let _service: WebSpeechTranscriptionService | null = null
+const MODE_STORAGE_KEY = 'talkscope.transcription.mode'
+const DEFAULT_MODE: TranscriptionMode = (import.meta.env.VITE_TRANSCRIPTION_MODE_DEFAULT === 'accurate' ? 'accurate' : 'fast')
+const services: Record<TranscriptionMode, ITranscriptionService> = {
+  fast: new WebSpeechTranscriptionService(),
+  accurate: new LocalSttTranscriptionService(),
+}
+let _mode: TranscriptionMode = DEFAULT_MODE
 
-/** アプリ全体で共有する文字起こしサービス（デモツールバーなどフック外からも利用） */
-export function getTranscriptionService(): WebSpeechTranscriptionService {
-  if (!_service) _service = new WebSpeechTranscriptionService()
-  return _service
+if (typeof window !== 'undefined') {
+  const saved = window.localStorage.getItem(MODE_STORAGE_KEY)
+  if (saved === 'fast' || saved === 'accurate') _mode = saved
+}
+
+export function getTranscriptionMode(): TranscriptionMode {
+  return _mode
+}
+
+export function setTranscriptionMode(mode: TranscriptionMode): void {
+  if (_mode === mode) return
+  const prevService = services[_mode]
+  prevService.stopListening()
+  _mode = mode
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(MODE_STORAGE_KEY, mode)
+  }
+}
+
+/** アプリ全体で共有する現在モードの文字起こしサービス */
+export function getTranscriptionService(): ITranscriptionService {
+  return services[_mode]
 }
 
 export function useTranscription() {
@@ -17,7 +41,8 @@ export function useTranscription() {
   const setStatus = useTranscriptStore(s => s.setStatus)
   const transcript = useTranscriptStore(s => s.transcript)
   const status = useTranscriptStore(s => s.status)
-  const serviceRef = useRef(getTranscriptionService())
+  const [mode, setMode] = useState<TranscriptionMode>(getTranscriptionMode())
+  const serviceRef = useRef<ITranscriptionService>(getTranscriptionService())
   const [microphones, setMicrophones] = useState<MicrophoneDevice[]>(serviceRef.current.getAvailableMicrophones())
   const [selectedMicrophoneId, setSelectedMicrophoneId] = useState(serviceRef.current.getSelectedMicrophoneId())
 
@@ -31,9 +56,22 @@ export function useTranscription() {
       setSelectedMicrophoneId(service.getSelectedMicrophoneId())
     })
     return unsubscribe
-  }, [setTranscript, setStatus])
+  }, [mode, setTranscript, setStatus])
+
+  const changeMode = (nextMode: TranscriptionMode) => {
+    setTranscriptionMode(nextMode)
+    const nextService = getTranscriptionService()
+    serviceRef.current = nextService
+    setMode(nextMode)
+    setTranscript(nextService.getTranscript())
+    setStatus(nextService.getStatus())
+    setMicrophones(nextService.getAvailableMicrophones())
+    setSelectedMicrophoneId(nextService.getSelectedMicrophoneId())
+    void nextService.refreshMicrophones()
+  }
 
   return {
+    mode,
     transcript,
     status,
     isListening: status === 'listening',
@@ -41,6 +79,7 @@ export function useTranscription() {
     selectedMicrophoneId,
     refreshMicrophones: () => serviceRef.current.refreshMicrophones(),
     selectMicrophone: (deviceId: string) => serviceRef.current.setSelectedMicrophone(deviceId),
+    setMode: changeMode,
     startListening: () => serviceRef.current.startListening(),
     stopListening: () => serviceRef.current.stopListening(),
     clearTranscript: () => {

--- a/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
+++ b/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
@@ -11,8 +11,10 @@ export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) 
   const {
     transcript,
     isListening,
+    mode,
     startListening,
     stopListening,
+    setMode,
     microphones,
     selectedMicrophoneId,
     refreshMicrophones,
@@ -32,6 +34,8 @@ export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) 
     <TranscriptionView
       transcript={transcript}
       isListening={isListening}
+      mode={mode}
+      onChangeMode={setMode}
       onToggleListening={handleToggleListening}
       microphones={microphones}
       selectedMicrophoneId={selectedMicrophoneId}

--- a/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
+++ b/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
@@ -8,7 +8,16 @@ import type { Term } from '../../../domain/entities/Term'
 
 export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const demoStream = useDemoTools()
-  const { transcript, isListening, startListening, stopListening } = useTranscription()
+  const {
+    transcript,
+    isListening,
+    startListening,
+    stopListening,
+    microphones,
+    selectedMicrophoneId,
+    refreshMicrophones,
+    selectMicrophone,
+  } = useTranscription()
   const selectTerm = useTermStore(s => s.selectTerm)
   const togglePin = useTermStore(s => s.togglePin)
   const isPinned = useTermStore(s => s.pinnedTermIds)
@@ -24,6 +33,10 @@ export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) 
       transcript={transcript}
       isListening={isListening}
       onToggleListening={handleToggleListening}
+      microphones={microphones}
+      selectedMicrophoneId={selectedMicrophoneId}
+      onRefreshMicrophones={refreshMicrophones}
+      onSelectMicrophone={selectMicrophone}
       showEmbeddedResetButton={false}
       onTermClick={(term: Term) => selectTerm(term)}
       onTermHover={() => {}}

--- a/Frontend/src/vite-env.d.ts
+++ b/Frontend/src/vite-env.d.ts
@@ -3,6 +3,8 @@
 interface ImportMetaEnv {
   readonly VITE_BACKEND_URL?: string;
   readonly VITE_VECTOR_API_URL?: string;
+  readonly VITE_TRANSCRIPT_UPLOAD_MODE?: 'disabled' | 'local' | 'remote';
+  readonly VITE_TRANSCRIPT_UPLOAD_URL?: string;
   readonly VITE_VECTOR_OVERLAP_SENTENCES?: string;
   readonly VITE_VECTOR_SEND_EVERY_N_SENTENCES?: string;
   readonly VITE_VECTOR_SEND_INTERVAL_SEC?: string;

--- a/Frontend/src/vite-env.d.ts
+++ b/Frontend/src/vite-env.d.ts
@@ -3,6 +3,8 @@
 interface ImportMetaEnv {
   readonly VITE_BACKEND_URL?: string;
   readonly VITE_VECTOR_API_URL?: string;
+  readonly VITE_TRANSCRIPTION_MODE_DEFAULT?: 'fast' | 'accurate';
+  readonly VITE_LOCAL_STT_URL?: string;
   readonly VITE_TRANSCRIPT_UPLOAD_MODE?: 'disabled' | 'local' | 'remote';
   readonly VITE_TRANSCRIPT_UPLOAD_URL?: string;
   readonly VITE_VECTOR_OVERLAP_SENTENCES?: string;

--- a/Frontend/tests/local-server/transcriptReceiver.mjs
+++ b/Frontend/tests/local-server/transcriptReceiver.mjs
@@ -1,0 +1,66 @@
+import { createServer } from 'node:http'
+
+const host = process.env.HOST || '0.0.0.0'
+const port = Number(process.env.PORT || 8000)
+
+const server = createServer((req, res) => {
+  const path = req.url || '/'
+  console.log(`[local-server] ${req.method} ${path}`)
+
+  const origin = req.headers.origin || '*'
+  res.setHeader('Access-Control-Allow-Origin', origin)
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204)
+    res.end()
+    return
+  }
+
+  if (req.method === 'GET' && path === '/') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ ok: true, endpoint: '/transcript' }))
+    return
+  }
+
+  if (req.method === 'GET' && path === '/favicon.ico') {
+    res.writeHead(204)
+    res.end()
+    return
+  }
+
+  if (req.method === 'POST' && path === '/transcript') {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf-8')
+      let parsed
+      try {
+        parsed = JSON.parse(raw)
+      } catch {
+        parsed = raw
+      }
+
+      console.log('=== transcript received ===')
+      console.log({
+        path,
+        receivedAt: new Date().toISOString(),
+        body: parsed,
+      })
+
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ ok: true }))
+    })
+    return
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify({ ok: false, message: 'Not Found' }))
+})
+
+server.listen(port, host, () => {
+  console.log(`[local-server] listening on http://${host}:${port}`)
+  console.log('[local-server] endpoint: POST /transcript')
+})
+

--- a/Frontend/tests/local-stt/README.md
+++ b/Frontend/tests/local-stt/README.md
@@ -1,0 +1,42 @@
+# Local STT Server (Accurate Mode)
+
+`accurate` モードで使う、無料・PC内完結の文字起こしサーバーです。
+
+## 1. セットアップ
+
+```bash
+cd Frontend/tests/local-stt
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## 2. サーバー起動
+
+```bash
+uvicorn server:app --host 127.0.0.1 --port 8765
+```
+
+初回はモデルダウンロードで時間がかかります。
+
+## 3. Frontend の設定
+
+`Frontend/.env.local` に以下を設定:
+
+```env
+VITE_TRANSCRIPTION_MODE_DEFAULT=fast
+VITE_LOCAL_STT_URL=http://127.0.0.1:8765/transcribe
+```
+
+## 4. 使い方
+
+1. Frontend で文字起こしウィンドウを開く
+2. モードを `正確さ重視` に切替
+3. 録音開始 → 録音停止
+4. 停止後、ローカルSTT結果が反映される
+
+## 補足
+
+- `速度重視` は WebSpeechAPI（リアルタイム）
+- `正確さ重視` は停止後に local STT で再認識
+- どちらも無料で利用可能

--- a/Frontend/tests/local-stt/requirements.txt
+++ b/Frontend/tests/local-stt/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+python-multipart
+faster-whisper

--- a/Frontend/tests/local-stt/server.py
+++ b/Frontend/tests/local-stt/server.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI, File, Form, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from faster_whisper import WhisperModel
+import tempfile
+import os
+
+app = FastAPI(title="TalkScope Local STT")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+MODEL_NAME = os.getenv("WHISPER_MODEL", "small")
+model = WhisperModel(MODEL_NAME, device="cpu", compute_type="int8")
+
+
+@app.get("/")
+def health():
+    return {"ok": True, "model": MODEL_NAME}
+
+
+@app.post("/transcribe")
+async def transcribe(file: UploadFile = File(...), language: str = Form("ja")):
+    suffix = ".webm"
+    if file.filename and "." in file.filename:
+        suffix = "." + file.filename.split(".")[-1]
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        data = await file.read()
+        tmp.write(data)
+        path = tmp.name
+
+    try:
+        segments, _info = model.transcribe(path, language=language, vad_filter=True)
+        text = "".join(seg.text for seg in segments).strip()
+        return {"text": text}
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+


### PR DESCRIPTION
## 概要

文字起こし周りの検証と運用しやすさを改善する変更です（base: `develop/v0`）。

## 主な変更

- **録音停止時の全文アップロード**: 環境変数で `disabled` / `local` / `remote` を切替（`VITE_TRANSCRIPT_UPLOAD_*`）
- **ローカル受信テスト用**: `Frontend/tests/local-server/` と `bun run test:local-server`
- **WebSpeech**: 未確定テキストが消えにくいよう内部バッファを調整
- **マイク選択**: 録音UI付近でデバイス列挙・選択
- **速度重視 / 正確さ重視**: `fast`（WebSpeech）と `accurate`（ローカルSTT）をUIと `localStorage` で切替
- **ローカルSTT検証用**: `Frontend/tests/local-stt/`（FastAPI + faster-whisper 例）と `bun run test:local-stt-server`

## 確認方法

1. 文字起こしウィンドウでモード切替・録音
2. オプション: `.env.local` でアップロードモード・ローカルSTT URL を設定し、`tests/local-*` の手順に沿ってサーバー起動

## 注意

- `accurate` モードはローカルSTTサーバー起動が前提です（README 参照）
- WebSpeech へのマイクバインドはブラウザ実装依存です

（旧 PR #21 は `main` 向けのためクローズ済み。本 PR は `develop/v0` 向けです。）

Made with [Cursor](https://cursor.com)