### PR TITLE
feat(frontend): 操作ドック・ヘッダー整理と最小サイズ

### DIFF
--- a/Frontend/src/app/components/SettingsModal.tsx
+++ b/Frontend/src/app/components/SettingsModal.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { Settings, X, Moon, Sun, Palette, SlidersHorizontal, Loader2 } from 'lucide-react';
+import { Settings, X, Moon, Sun, Palette, SlidersHorizontal, Loader2, Mic } from 'lucide-react';
+import { useTranscription } from '../../presentation/hooks/useTranscription';
+import type { TranscriptionMode } from '../../domain/interfaces/ITranscriptionService';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -43,9 +45,29 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   similarityReferenceWord = 'it',
   similarityReady = false,
 }) => {
+  const { mode, setMode, microphones, selectedMicrophoneId, selectMicrophone, refreshMicrophones } = useTranscription();
+
   if (!isOpen) return null;
 
   const dk = settings.darkMode;
+
+  const modeBtn = (val: TranscriptionMode, label: string) => (
+    <button
+      key={val}
+      onClick={() => setMode(val)}
+      className={`flex-1 rounded-lg border py-1.5 text-xs font-bold transition-colors ${
+        mode === val
+          ? dk
+            ? 'border-indigo-500 bg-indigo-500/15 text-indigo-300'
+            : 'border-indigo-500 bg-indigo-50 text-indigo-700'
+          : dk
+            ? 'border-slate-700 text-slate-400 hover:bg-slate-800'
+            : 'border-slate-200 text-slate-500 hover:bg-slate-50'
+      }`}
+    >
+      {label}
+    </button>
+  );
 
   return (
     <AnimatePresence>
@@ -57,7 +79,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
           onClick={onClose}
           className={`absolute inset-0 ${dk ? 'bg-black/60' : 'bg-slate-900/50'} backdrop-blur-sm`}
         />
-        
+
         <motion.div
           initial={{ opacity: 0, scale: 0.95, y: 16 }}
           animate={{ opacity: 1, scale: 1, y: 0 }}
@@ -65,27 +87,28 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
           transition={{ duration: 0.2 }}
           className={`relative w-full max-w-md rounded-2xl shadow-2xl overflow-hidden border ${dk ? 'bg-[#12132a] border-slate-800/60 text-slate-100' : 'bg-white border-slate-200 text-slate-900'}`}
         >
-          <div className="p-5">
-            <div className="flex justify-between items-center mb-5">
+          <div className="p-4">
+            <div className="flex justify-between items-center mb-4">
               <div className="flex items-center gap-2">
                 <Settings size={16} className="text-indigo-400" />
-                <h2 className="text-lg font-black">設定</h2>
+                <h2 className="text-base font-black">設定</h2>
               </div>
               <button onClick={onClose} className={`p-1.5 rounded-lg transition-colors ${dk ? 'hover:bg-slate-800 text-slate-500' : 'hover:bg-slate-100 text-slate-400'}`}>
                 <X size={18} />
               </button>
             </div>
 
-            <div className="space-y-5">
+            <div className="space-y-4">
+
               {/* Display Settings */}
               <section>
                 <div className={`flex items-center gap-1.5 mb-3 text-[10px] font-bold uppercase tracking-widest ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
                   <Palette size={12} /> 表示
                 </div>
-                
+
                 <div className="flex items-center justify-between mb-3.5">
                   <span className="text-xs font-bold">ダークモード</span>
-                  <button 
+                  <button
                     onClick={() => updateSettings({ darkMode: !settings.darkMode })}
                     className={`w-10 h-5 rounded-full relative transition-colors ${settings.darkMode ? 'bg-indigo-600' : 'bg-slate-200'}`}
                   >
@@ -95,7 +118,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                   </button>
                 </div>
 
-                <div className="mb-3.5">
+                <div>
                   <span className="text-xs font-bold block mb-2">アクセントカラー</span>
                   <div className="flex gap-2">
                     {THEME_COLORS.map(color => (
@@ -107,6 +130,54 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                       />
                     ))}
                   </div>
+                </div>
+              </section>
+
+              {/* 文字起こし（モード・マイク）— 操作ドックの詳細はここに集約 */}
+              <section>
+                <div className={`flex items-center gap-1.5 mb-2.5 text-[10px] font-bold uppercase tracking-widest ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
+                  <Mic size={12} /> 文字起こし
+                </div>
+
+                <div className="mb-3">
+                  <span className="text-xs font-bold block mb-1.5">モード</span>
+                  <div className="flex gap-2">
+                    {modeBtn('fast', '速度重視')}
+                    {modeBtn('accurate', '正確さ重視')}
+                  </div>
+                  <p className={`mt-1 text-[10px] ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
+                    {mode === 'fast' ? 'WebSpeechでリアルタイム寄り' : '停止後にローカルSTTで高精度化'}
+                  </p>
+                </div>
+
+                <div>
+                  <div className="mb-1.5 flex items-center justify-between gap-2">
+                    <span className="text-xs font-bold">マイク</span>
+                    <button
+                      type="button"
+                      onClick={() => void refreshMicrophones()}
+                      className={`shrink-0 rounded-md border px-2 py-0.5 text-[10px] font-bold transition-colors ${
+                        dk
+                          ? 'border-slate-600 bg-slate-800 text-slate-300 hover:bg-slate-700'
+                          : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-50'
+                      }`}
+                      title="マイク一覧を再取得"
+                    >
+                      更新
+                    </button>
+                  </div>
+                  <select
+                    value={selectedMicrophoneId}
+                    onChange={(e) => selectMicrophone(e.target.value)}
+                    className={`w-full rounded-lg border px-2.5 py-1.5 text-xs ${
+                      dk ? 'bg-slate-800 border-slate-700 text-slate-200' : 'bg-white border-slate-300 text-slate-700'
+                    }`}
+                  >
+                    {microphones.length === 0 && <option value="">利用可能マイクなし</option>}
+                    {microphones.map((mic) => (
+                      <option key={mic.deviceId} value={mic.deviceId}>{mic.label}</option>
+                    ))}
+                  </select>
                 </div>
               </section>
 

--- a/Frontend/src/app/components/TranscriptionView.tsx
+++ b/Frontend/src/app/components/TranscriptionView.tsx
@@ -3,16 +3,19 @@ import { createPortal } from 'react-dom';
 import { highlightTerms } from '../utils/termDetection';
 import { Term } from '../data/terms';
 import { motion, AnimatePresence } from 'motion/react';
-import { Mic, Square, Radio, Play, RotateCcw, FastForward, Pause, LoaderCircle, Star } from 'lucide-react';
+import { Radio, Play, RotateCcw, FastForward, Pause, LoaderCircle, Star } from 'lucide-react';
 import { UseDemoStreamReturn } from '../../debug/hooks/useDemoStream';
 import type { MicrophoneDevice, TranscriptionMode } from '../../domain/interfaces/ITranscriptionService';
+import { RecordingToolbar } from '../../presentation/components/RecordingToolbar';
 
 const TOOLTIP = { W: 208, H: 100, PAD: 8, GAP_ABOVE: 12 } as const;
 
 interface TranscriptionViewProps {
   transcript: string;
   isListening: boolean;
-  onToggleListening: () => void;
+  onToggleListening?: () => void;
+  /** false のとき録音・モード・マイクは操作ウィンドウ側に集約 */
+  showRecordingCluster?: boolean;
   mode?: TranscriptionMode;
   onChangeMode?: (mode: TranscriptionMode) => void;
   microphones?: MicrophoneDevice[];
@@ -40,6 +43,7 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
   transcript,
   isListening,
   onToggleListening,
+  showRecordingCluster = true,
   mode = 'fast',
   onChangeMode,
   microphones = [],
@@ -301,99 +305,21 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
             </div>
           )}
 
-          {/* 録音開始/中断ボタン（メイン） */}
-          <div className="flex flex-col items-center gap-1.5">
-            <AnimatePresence mode="wait">
-              {isListening ? (
-                <motion.button
-                  key="stop"
-                  onClick={onToggleListening}
-                  initial={{ scale: 0.8, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  exit={{ scale: 0.8, opacity: 0 }}
-                  transition={{ type: 'spring', stiffness: 300, damping: 22 }}
-                  whileTap={{ scale: 0.92 }}
-                  className="w-20 h-20 rounded-full flex items-center justify-center relative shadow-2xl bg-red-500 hover:bg-red-400 text-white shadow-red-500/30"
-                  title="録音を中断"
-                >
-                  <span className="absolute inset-0 rounded-full bg-red-400 animate-ping opacity-25 pointer-events-none" />
-                  <Square size={26} fill="currentColor" />
-                </motion.button>
-              ) : (
-                <motion.button
-                  key="start"
-                  onClick={onToggleListening}
-                  initial={{ scale: 0.8, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  exit={{ scale: 0.8, opacity: 0 }}
-                  transition={{ type: 'spring', stiffness: 300, damping: 22 }}
-                  whileTap={{ scale: 0.92 }}
-                  className={`w-20 h-20 rounded-full flex items-center justify-center shadow-2xl ${
-                    dk
-                      ? 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/40'
-                      : 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/30'
-                  }`}
-                  title="録音開始"
-                >
-                  <Mic size={32} />
-                </motion.button>
-              )}
-            </AnimatePresence>
-            <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
-              {isListening ? '中断' : '録音開始'}
-            </span>
-            <div className="mt-1 flex items-center gap-1.5">
-              <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>モード</span>
-              <select
-                value={mode}
-                onChange={(e) => onChangeMode?.(e.target.value as TranscriptionMode)}
-                className={`rounded-md border px-2 py-1 text-[10px] ${
-                  dk
-                    ? 'bg-slate-800 border-slate-700 text-slate-200'
-                    : 'bg-white border-slate-300 text-slate-700'
-                }`}
-                title="文字起こしモードを選択"
-              >
-                <option value="fast">速度重視</option>
-                <option value="accurate">正確さ重視</option>
-              </select>
-            </div>
-            <span className={`text-[9px] ${dk ? 'text-slate-600' : 'text-slate-400'}`}>
-              {mode === 'fast' ? 'WebSpeechでリアルタイム寄り' : '停止後にローカルSTTで高精度化'}
-            </span>
-            <div className="mt-1 flex items-center gap-1.5">
-              <select
-                value={selectedMicrophoneId}
-                onChange={(e) => onSelectMicrophone?.(e.target.value)}
-                className={`max-w-[180px] rounded-md border px-2 py-1 text-[10px] ${
-                  dk
-                    ? 'bg-slate-800 border-slate-700 text-slate-200'
-                    : 'bg-white border-slate-300 text-slate-700'
-                }`}
-                title="使用するマイクを選択"
-              >
-                {microphones.length === 0 && (
-                  <option value="">利用可能マイクなし</option>
-                )}
-                {microphones.map((mic) => (
-                  <option key={mic.deviceId} value={mic.deviceId}>
-                    {mic.label}
-                  </option>
-                ))}
-              </select>
-              <button
-                onClick={onRefreshMicrophones}
-                className={`rounded-md border px-2 py-1 text-[10px] font-bold ${
-                  dk
-                    ? 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700'
-                    : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
-                }`}
-                title="マイク一覧を再取得"
-              >
-                更新
-              </button>
-            </div>
-          </div>
+          {/* 録音開始/中断・モード・マイク（操作ウィンドウに移したときは非表示） */}
+          {showRecordingCluster && onToggleListening && (
+            <RecordingToolbar
+              darkMode={darkMode}
+              isListening={isListening}
+              onToggleListening={onToggleListening}
+              mode={mode}
+              onChangeMode={onChangeMode ?? (() => {})}
+              microphones={microphones}
+              selectedMicrophoneId={selectedMicrophoneId}
+              onSelectMicrophone={onSelectMicrophone ?? (() => {})}
+              onRefreshMicrophones={onRefreshMicrophones ?? (() => {})}
+              variant={onChangeMode && onSelectMicrophone && onRefreshMicrophones ? 'full' : 'recordOnly'}
+            />
+          )}
 
           {/* ライブデモボタン＋速度スライダー（右側） */}
           {demoStream && showEmbeddedDemoControls && (

--- a/Frontend/src/domain/interfaces/ITranscriptionService.ts
+++ b/Frontend/src/domain/interfaces/ITranscriptionService.ts
@@ -17,4 +17,6 @@ export interface ITranscriptionService {
   clearTranscript(): void
   /** デモ・テスト用に全文を差し替え（音声入力とは独立） */
   setTranscriptExternal(text: string): void
+  /** 書き起こし・ステータス・マイク一覧の変更通知（購読解除関数を返す） */
+  subscribe(listener: () => void): () => void
 }

--- a/Frontend/src/presentation/App.tsx
+++ b/Frontend/src/presentation/App.tsx
@@ -71,7 +71,11 @@ const App: React.FC = () => {
         <div
           className={`w-screen h-screen flex flex-col overflow-hidden ${dk ? 'bg-[#0a0b14] text-slate-100' : 'bg-slate-50 text-slate-900'}`}
         >
-          <PresentationAppHeader darkMode={darkMode} currentPhaseId={currentPhaseId} />
+          <PresentationAppHeader
+            darkMode={darkMode}
+            currentPhaseId={currentPhaseId}
+            onOpenAppearance={() => setAppearanceOpen(true)}
+          />
 
           {/* フェーズコンテンツ */}
           <div className="flex-1 overflow-hidden">

--- a/Frontend/src/presentation/App.tsx
+++ b/Frontend/src/presentation/App.tsx
@@ -5,6 +5,7 @@ import { AfterPresentation } from './phases/AfterPresentation'
 import { usePhaseStore } from '../stores/phaseStore'
 import { registerAllWindows } from './windows'
 import { PresentationAppHeader } from './components/PresentationAppHeader'
+import { PresentationShellProvider } from './context/PresentationShellContext'
 import { DemoToolsProvider } from './context/DemoToolsContext'
 import { useDemoStream } from '../debug/hooks/useDemoStream'
 import { getTranscriptionService } from './hooks/useTranscription'
@@ -60,34 +61,36 @@ const App: React.FC = () => {
 
   return (
     <DemoToolsProvider value={demoStream}>
-      <DemoImportantTermsBridge />
-      <div
-        className={`w-screen h-screen flex flex-col overflow-hidden ${dk ? 'bg-[#0a0b14] text-slate-100' : 'bg-slate-50 text-slate-900'}`}
+      <PresentationShellProvider
+        value={{
+          onOpenAppearance: () => setAppearanceOpen(true),
+          onResetAll: resetAllWindows,
+        }}
       >
-        <PresentationAppHeader
-          darkMode={darkMode}
-          currentPhaseId={currentPhaseId}
-          onReset={resetAllWindows}
-          onOpenAppearance={() => setAppearanceOpen(true)}
-        />
+        <DemoImportantTermsBridge />
+        <div
+          className={`w-screen h-screen flex flex-col overflow-hidden ${dk ? 'bg-[#0a0b14] text-slate-100' : 'bg-slate-50 text-slate-900'}`}
+        >
+          <PresentationAppHeader darkMode={darkMode} currentPhaseId={currentPhaseId} />
 
-        {/* フェーズコンテンツ */}
-        <div className="flex-1 overflow-hidden">
-          {currentPhaseId === 'during'
-            ? <DuringPresentation darkMode={darkMode} themeColor={phaseAccentColor} />
-            : <AfterPresentation darkMode={darkMode} themeColor={phaseAccentColor} />
-          }
+          {/* フェーズコンテンツ */}
+          <div className="flex-1 overflow-hidden">
+            {currentPhaseId === 'during'
+              ? <DuringPresentation darkMode={darkMode} themeColor={phaseAccentColor} />
+              : <AfterPresentation darkMode={darkMode} themeColor={phaseAccentColor} />
+            }
+          </div>
+
+          <SettingsModal
+            isOpen={appearanceOpen}
+            onClose={() => setAppearanceOpen(false)}
+            settings={appearance}
+            updateSettings={partial => setAppearance(prev => ({ ...prev, ...partial }))}
+          />
+
+          <Toaster position="bottom-right" theme={darkMode ? 'dark' : 'light'} />
         </div>
-
-        <SettingsModal
-          isOpen={appearanceOpen}
-          onClose={() => setAppearanceOpen(false)}
-          settings={appearance}
-          updateSettings={partial => setAppearance(prev => ({ ...prev, ...partial }))}
-        />
-
-        <Toaster position="bottom-right" theme={darkMode ? 'dark' : 'light'} />
-      </div>
+      </PresentationShellProvider>
     </DemoToolsProvider>
   )
 }

--- a/Frontend/src/presentation/components/LayoutPresetMenu.tsx
+++ b/Frontend/src/presentation/components/LayoutPresetMenu.tsx
@@ -26,6 +26,8 @@ interface Props {
   disabled?: boolean
   /** 操作ドックなど狭い場所向けの小さめトリガー */
   compact?: boolean
+  /** アイコン横に「レイアウト」などのラベルを表示（ヘッダー用） */
+  labeled?: boolean
 }
 
 const focusRing =
@@ -37,6 +39,7 @@ export const LayoutPresetMenu: React.FC<Props> = ({
   menuAlign = 'right',
   disabled = false,
   compact = false,
+  labeled = false,
 }) => {
   const [open, setOpen] = useState(false)
   const setLayout = useLayoutStore(s => s.setLayout)
@@ -51,9 +54,23 @@ export const LayoutPresetMenu: React.FC<Props> = ({
     if (!disabled) setOpen(v => !v)
   }
 
+  const iconSize = compact ? 15 : labeled ? 16 : 18
+
+  const triggerIconOnly = `relative z-0 flex shrink-0 items-center justify-center rounded-full transition-colors ${compact ? 'size-8' : 'size-10'} ${focusRing} ${ringOffset} ${darkMode
+    ? 'text-slate-300 hover:bg-slate-800 hover:text-slate-100'
+    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'} ${disabled
+    ? 'pointer-events-none opacity-[0.42] saturate-50'
+    : ''}`
+
+  const triggerLabeled = `relative z-0 flex min-h-9 shrink-0 flex-row items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-bold transition-colors ${focusRing} ${ringOffset} ${darkMode
+    ? 'border-slate-700/80 bg-slate-900/25 text-slate-200 hover:bg-slate-800'
+    : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'} ${disabled
+    ? 'pointer-events-none cursor-not-allowed opacity-[0.42] saturate-50'
+    : ''}`
+
   return (
     <div
-      className={`relative inline-flex rounded-full ${disabled ? 'cursor-not-allowed' : ''}`}
+      className={`relative inline-flex ${labeled ? 'rounded-lg' : 'rounded-full'} ${disabled ? 'cursor-not-allowed' : ''}`}
       title={disabled ? '発表中のみレイアウトを変更できます' : undefined}
     >
       <button
@@ -63,17 +80,14 @@ export const LayoutPresetMenu: React.FC<Props> = ({
         aria-label={disabled ? 'レイアウトプリセット（発表後は利用不可）' : 'レイアウトプリセットを開く'}
         aria-expanded={!disabled && open}
         aria-disabled={disabled}
-        className={`relative z-0 flex shrink-0 items-center justify-center rounded-full transition-colors ${compact ? 'size-8' : 'size-10'} ${focusRing} ${ringOffset} ${darkMode
-          ? 'text-slate-300 hover:bg-slate-800 hover:text-slate-100'
-          : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'} ${disabled
-          ? 'pointer-events-none opacity-[0.42] saturate-50'
-          : ''}`}
+        className={labeled ? triggerLabeled : triggerIconOnly}
       >
-        <LayoutGrid size={compact ? 15 : 18} strokeWidth={2} />
+        <LayoutGrid size={iconSize} strokeWidth={2} />
+        {labeled ? <span className="whitespace-nowrap">レイアウト</span> : null}
       </button>
       {disabled ? (
         <span
-          className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center overflow-hidden rounded-full"
+          className={`pointer-events-none absolute inset-0 z-10 flex items-center justify-center overflow-hidden ${labeled ? 'rounded-lg' : 'rounded-full'}`}
           aria-hidden
         >
           <span

--- a/Frontend/src/presentation/components/LayoutPresetMenu.tsx
+++ b/Frontend/src/presentation/components/LayoutPresetMenu.tsx
@@ -54,15 +54,15 @@ export const LayoutPresetMenu: React.FC<Props> = ({
     if (!disabled) setOpen(v => !v)
   }
 
-  const iconSize = compact ? 15 : labeled ? 16 : 18
+  const iconSize = compact ? 16 : labeled ? 17 : 18
 
-  const triggerIconOnly = `relative z-0 flex shrink-0 items-center justify-center rounded-full transition-colors ${compact ? 'size-8' : 'size-10'} ${focusRing} ${ringOffset} ${darkMode
+  const triggerIconOnly = `relative z-0 flex shrink-0 items-center justify-center rounded-full transition-colors ${compact ? 'size-9' : 'size-11'} ${focusRing} ${ringOffset} ${darkMode
     ? 'text-slate-300 hover:bg-slate-800 hover:text-slate-100'
     : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'} ${disabled
     ? 'pointer-events-none opacity-[0.42] saturate-50'
     : ''}`
 
-  const triggerLabeled = `relative z-0 flex min-h-9 shrink-0 flex-row items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-bold transition-colors ${focusRing} ${ringOffset} ${darkMode
+  const triggerLabeled = `relative z-0 flex min-h-10 shrink-0 flex-row items-center gap-2 rounded-lg border px-3 py-2 text-sm font-bold transition-colors ${focusRing} ${ringOffset} ${darkMode
     ? 'border-slate-700/80 bg-slate-900/25 text-slate-200 hover:bg-slate-800'
     : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'} ${disabled
     ? 'pointer-events-none cursor-not-allowed opacity-[0.42] saturate-50'

--- a/Frontend/src/presentation/components/LayoutPresetMenu.tsx
+++ b/Frontend/src/presentation/components/LayoutPresetMenu.tsx
@@ -24,6 +24,8 @@ interface Props {
   menuAlign?: 'left' | 'right'
   /** true のとき表示は維持するが操作不可（発表後など） */
   disabled?: boolean
+  /** 操作ドックなど狭い場所向けの小さめトリガー */
+  compact?: boolean
 }
 
 const focusRing =
@@ -34,6 +36,7 @@ export const LayoutPresetMenu: React.FC<Props> = ({
   phaseId,
   menuAlign = 'right',
   disabled = false,
+  compact = false,
 }) => {
   const [open, setOpen] = useState(false)
   const setLayout = useLayoutStore(s => s.setLayout)
@@ -60,13 +63,13 @@ export const LayoutPresetMenu: React.FC<Props> = ({
         aria-label={disabled ? 'レイアウトプリセット（発表後は利用不可）' : 'レイアウトプリセットを開く'}
         aria-expanded={!disabled && open}
         aria-disabled={disabled}
-        className={`relative z-0 flex size-10 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${darkMode
+        className={`relative z-0 flex shrink-0 items-center justify-center rounded-full transition-colors ${compact ? 'size-8' : 'size-10'} ${focusRing} ${ringOffset} ${darkMode
           ? 'text-slate-300 hover:bg-slate-800 hover:text-slate-100'
           : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'} ${disabled
           ? 'pointer-events-none opacity-[0.42] saturate-50'
           : ''}`}
       >
-        <LayoutGrid size={18} strokeWidth={2} />
+        <LayoutGrid size={compact ? 15 : 18} strokeWidth={2} />
       </button>
       {disabled ? (
         <span

--- a/Frontend/src/presentation/components/PhaseTransitionButton.tsx
+++ b/Frontend/src/presentation/components/PhaseTransitionButton.tsx
@@ -38,7 +38,7 @@ export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compac
       ? 'bg-gradient-to-b from-emerald-500 to-emerald-700 text-white shadow-emerald-900/40 hover:from-emerald-400 hover:to-emerald-600'
       : 'bg-gradient-to-b from-emerald-500 to-emerald-600 text-white shadow-emerald-900/25 hover:from-emerald-600 hover:to-emerald-700'
 
-  const iconSize = compact ? 14 : 22
+  const iconSize = compact ? 16 : 22
 
   return (
     <button
@@ -48,7 +48,7 @@ export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compac
       aria-label={isDuring ? '発表を終了する' : '発表中に戻る'}
       className={`inline-flex items-center justify-center font-bold leading-none shadow-md transition-transform active:scale-[0.98] ${
         compact
-          ? 'min-h-10 h-10 min-w-0 flex-1 flex-row gap-1 rounded-lg px-2 text-[10px] hover:scale-[1.01]'
+          ? 'min-h-11 h-11 min-w-0 flex-1 flex-row gap-1.5 rounded-lg px-2.5 text-[11px] hover:scale-[1.01]'
           : 'w-full h-[3.25rem] shrink-0 gap-2.5 rounded-xl px-6 text-sm whitespace-nowrap shadow-lg hover:scale-[1.01]'
       } ${focusRing} ${ringOffset} ${surface}`}
     >

--- a/Frontend/src/presentation/components/PhaseTransitionButton.tsx
+++ b/Frontend/src/presentation/components/PhaseTransitionButton.tsx
@@ -5,9 +5,11 @@ import { useBubbleStore } from '../../stores/bubbleStore'
 
 interface Props {
   darkMode?: boolean
+  /** 操作ドック内: 録音ボタンと横並びの低いボタン */
+  compact?: boolean
 }
 
-export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true }) => {
+export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compact = false }) => {
   const currentPhaseId = usePhaseStore(s => s.currentPhaseId)
   const transitionTo = usePhaseStore(s => s.transitionTo)
   const clearBubbles = useBubbleStore(s => s.clearBubbles)
@@ -36,23 +38,29 @@ export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true }) => {
       ? 'bg-gradient-to-b from-emerald-500 to-emerald-700 text-white shadow-emerald-900/40 hover:from-emerald-400 hover:to-emerald-600'
       : 'bg-gradient-to-b from-emerald-500 to-emerald-600 text-white shadow-emerald-900/25 hover:from-emerald-600 hover:to-emerald-700'
 
+  const iconSize = compact ? 14 : 22
+
   return (
     <button
       type="button"
       onClick={handleClick}
       title={isDuring ? '発表を終了する' : '発表中に戻る'}
       aria-label={isDuring ? '発表を終了する' : '発表中に戻る'}
-      className={`inline-flex h-[3.25rem] w-[12.5rem] shrink-0 items-center justify-center gap-2.5 whitespace-nowrap rounded-full px-6 text-sm font-bold leading-none shadow-lg transition-transform hover:scale-[1.02] active:scale-[0.98] ${focusRing} ${ringOffset} ${surface}`}
+      className={`inline-flex items-center justify-center font-bold leading-none shadow-md transition-transform active:scale-[0.98] ${
+        compact
+          ? 'min-h-10 h-10 min-w-0 flex-1 flex-row gap-1 rounded-lg px-2 text-[10px] hover:scale-[1.01]'
+          : 'w-full h-[3.25rem] shrink-0 gap-2.5 rounded-xl px-6 text-sm whitespace-nowrap shadow-lg hover:scale-[1.01]'
+      } ${focusRing} ${ringOffset} ${surface}`}
     >
       {isDuring ? (
         <>
-          <StopCircle size={22} strokeWidth={2.25} className="shrink-0" />
-          発表終了
+          <StopCircle size={iconSize} strokeWidth={2.25} className="shrink-0" />
+          <span className="min-w-0 truncate">発表終了</span>
         </>
       ) : (
         <>
-          <Play size={22} strokeWidth={2.25} className="shrink-0" />
-          もどる
+          <Play size={iconSize} strokeWidth={2.25} className="shrink-0" />
+          <span className="min-w-0 truncate">もどる</span>
         </>
       )}
     </button>

--- a/Frontend/src/presentation/components/PresentationAppHeader.tsx
+++ b/Frontend/src/presentation/components/PresentationAppHeader.tsx
@@ -1,23 +1,35 @@
 import React from 'react'
+import { Settings } from 'lucide-react'
+import { LayoutPresetMenu } from './LayoutPresetMenu'
+import { TestFeaturesPopover } from './TestFeaturesPopover'
 
 export interface PresentationAppHeaderProps {
   darkMode: boolean
   currentPhaseId: string
+  onOpenAppearance: () => void
 }
 
+const focusRing =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:ring-offset-2'
+
 /**
- * プレゼンレイヤの最小ヘッダー（操作系は操作ウィンドウへ集約）。
+ * プレゼンレイヤのヘッダー（ブランド・フェーズ・レイアウト・設定・開発テスト）。
  */
 export const PresentationAppHeader: React.FC<PresentationAppHeaderProps> = ({
   darkMode,
   currentPhaseId,
+  onOpenAppearance,
 }) => {
   const dk = darkMode
   const isDuring = currentPhaseId === 'during'
+  const ringOffset = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
+  const settingsPill = dk
+    ? 'border-slate-700/80 bg-slate-900/25 text-slate-200 hover:bg-slate-800'
+    : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
 
   return (
     <header
-      className={`flex-shrink-0 flex flex-wrap items-center gap-3 px-4 py-2.5 border-b relative z-50 min-h-[3rem] ${dk ? 'bg-[#0d0e1a] border-slate-800' : 'bg-white border-slate-200'}`}
+      className={`flex-shrink-0 flex min-h-[3rem] flex-wrap items-center justify-between gap-2 border-b px-3 py-2 sm:gap-3 sm:px-4 sm:py-2.5 relative z-50 ${dk ? 'bg-[#0d0e1a] border-slate-800' : 'bg-white border-slate-200'}`}
     >
       <div className="flex min-w-0 flex-1 items-center gap-2.5 sm:gap-3">
         <span
@@ -38,6 +50,22 @@ export const PresentationAppHeader: React.FC<PresentationAppHeaderProps> = ({
         >
           {isDuring ? '発表中' : '発表後'}
         </span>
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-2" aria-label="ツールバー">
+        <LayoutPresetMenu darkMode={dk} phaseId="during" menuAlign="right" disabled={!isDuring} labeled />
+        <button
+          type="button"
+          onClick={onOpenAppearance}
+          title="設定（表示・文字起こし・マイクなど）"
+          className={`flex min-h-9 shrink-0 flex-row items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-bold transition-colors ${focusRing} ${ringOffset} ${settingsPill}`}
+          aria-haspopup="dialog"
+          aria-label="設定を開く"
+        >
+          <Settings size={16} strokeWidth={2} />
+          <span className="whitespace-nowrap">設定</span>
+        </button>
+        {import.meta.env.DEV ? <TestFeaturesPopover darkMode={dk} align="right" /> : null}
       </div>
     </header>
   )

--- a/Frontend/src/presentation/components/PresentationAppHeader.tsx
+++ b/Frontend/src/presentation/components/PresentationAppHeader.tsx
@@ -29,7 +29,7 @@ export const PresentationAppHeader: React.FC<PresentationAppHeaderProps> = ({
 
   return (
     <header
-      className={`flex-shrink-0 flex min-h-[3rem] flex-wrap items-center justify-between gap-2 border-b px-3 py-2 sm:gap-3 sm:px-4 sm:py-2.5 relative z-50 ${dk ? 'bg-[#0d0e1a] border-slate-800' : 'bg-white border-slate-200'}`}
+      className={`flex-shrink-0 flex min-h-[3.25rem] flex-wrap items-center justify-between gap-2 border-b px-3 py-2 sm:gap-3 sm:px-4 sm:py-2.5 relative z-50 ${dk ? 'bg-[#0d0e1a] border-slate-800' : 'bg-white border-slate-200'}`}
     >
       <div className="flex min-w-0 flex-1 items-center gap-2.5 sm:gap-3">
         <span
@@ -58,11 +58,11 @@ export const PresentationAppHeader: React.FC<PresentationAppHeaderProps> = ({
           type="button"
           onClick={onOpenAppearance}
           title="設定（表示・文字起こし・マイクなど）"
-          className={`flex min-h-9 shrink-0 flex-row items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-bold transition-colors ${focusRing} ${ringOffset} ${settingsPill}`}
+          className={`flex min-h-10 shrink-0 flex-row items-center gap-2 rounded-lg border px-3 py-2 text-sm font-bold transition-colors ${focusRing} ${ringOffset} ${settingsPill}`}
           aria-haspopup="dialog"
           aria-label="設定を開く"
         >
-          <Settings size={16} strokeWidth={2} />
+          <Settings size={17} strokeWidth={2} />
           <span className="whitespace-nowrap">設定</span>
         </button>
         {import.meta.env.DEV ? <TestFeaturesPopover darkMode={dk} align="right" /> : null}

--- a/Frontend/src/presentation/components/PresentationAppHeader.tsx
+++ b/Frontend/src/presentation/components/PresentationAppHeader.tsx
@@ -1,46 +1,24 @@
 import React from 'react'
-import { RotateCcw, Settings } from 'lucide-react'
-import { LayoutPresetMenu } from './LayoutPresetMenu'
-import { TestFeaturesPopover } from './TestFeaturesPopover'
-import { PhaseTransitionButton } from './PhaseTransitionButton'
-
-const focusRing =
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:ring-offset-2'
 
 export interface PresentationAppHeaderProps {
   darkMode: boolean
   currentPhaseId: string
-  onReset: () => void
-  onOpenAppearance: () => void
 }
 
 /**
- * プレゼンレイヤのグローバルツールバー。
- * 開発者向けテストは `import.meta.env.DEV` のときのみ左側（フェーズ表示の右）に表示。
+ * プレゼンレイヤの最小ヘッダー（操作系は操作ウィンドウへ集約）。
  */
 export const PresentationAppHeader: React.FC<PresentationAppHeaderProps> = ({
   darkMode,
   currentPhaseId,
-  onReset,
-  onOpenAppearance,
 }) => {
   const dk = darkMode
   const isDuring = currentPhaseId === 'during'
-  const ringOffset = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
-
-  const settingsBtn = dk
-    ? 'text-slate-300 hover:bg-slate-800 hover:text-white'
-    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
-
-  const resetBtn = dk
-    ? 'border border-amber-500/45 bg-amber-500/12 text-amber-300 hover:bg-amber-500/22 hover:border-amber-400/60'
-    : 'border border-amber-300/80 bg-amber-50 text-amber-900 hover:bg-amber-100 hover:border-amber-400'
 
   return (
     <header
       className={`flex-shrink-0 flex flex-wrap items-center gap-3 px-4 py-2.5 border-b relative z-50 min-h-[3rem] ${dk ? 'bg-[#0d0e1a] border-slate-800' : 'bg-white border-slate-200'}`}
     >
-      {/* 左: ブランド（強調） + フェーズ +（DEV のみ）テスト */}
       <div className="flex min-w-0 flex-1 items-center gap-2.5 sm:gap-3">
         <span
           className={`select-none text-2xl font-black tracking-tighter sm:text-3xl tabular-nums ${dk
@@ -60,36 +38,6 @@ export const PresentationAppHeader: React.FC<PresentationAppHeaderProps> = ({
         >
           {isDuring ? '発表中' : '発表後'}
         </span>
-        {import.meta.env.DEV ? (
-          <div className="shrink-0 border-l border-slate-600/40 pl-2.5 sm:pl-3">
-            <TestFeaturesPopover darkMode={darkMode} align="left" />
-          </div>
-        ) : null}
-      </div>
-
-      {/* 右: レイアウト（発表後は表示のみ・無効） | 設定 | リセット | フェーズ遷移 */}
-      <div className="ml-auto flex flex-wrap items-center gap-2 sm:gap-2.5">
-        <LayoutPresetMenu darkMode={darkMode} phaseId="during" menuAlign="right" disabled={!isDuring} />
-        <button
-          type="button"
-          onClick={onOpenAppearance}
-          title="設定"
-          className={`flex size-10 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${settingsBtn}`}
-          aria-haspopup="dialog"
-          aria-label="設定を開く"
-        >
-          <Settings size={18} strokeWidth={2} />
-        </button>
-        <button
-          type="button"
-          onClick={onReset}
-          title="文字起こし・用語・履歴などをすべてクリアします"
-          className={`flex size-11 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${resetBtn}`}
-          aria-label="すべてのウィンドウをリセット"
-        >
-          <RotateCcw size={19} strokeWidth={2} />
-        </button>
-        <PhaseTransitionButton darkMode={darkMode} />
       </div>
     </header>
   )

--- a/Frontend/src/presentation/components/RecordingToolbar.tsx
+++ b/Frontend/src/presentation/components/RecordingToolbar.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import { motion, AnimatePresence } from 'motion/react'
+import { Mic, Square } from 'lucide-react'
+import type { MicrophoneDevice, TranscriptionMode } from '../../domain/interfaces/ITranscriptionService'
+
+export type RecordingToolbarProps = {
+  darkMode?: boolean
+  isListening: boolean
+  onToggleListening: () => void
+  mode: TranscriptionMode
+  onChangeMode: (mode: TranscriptionMode) => void
+  microphones: MicrophoneDevice[]
+  selectedMicrophoneId: string
+  onSelectMicrophone: (deviceId: string) => void
+  onRefreshMicrophones: () => void
+  /** systemControl 内ではコンパクトに */
+  compact?: boolean
+  /** 旧 App 等: 録音ボタンのみ */
+  variant?: 'full' | 'recordOnly'
+}
+
+export const RecordingToolbar: React.FC<RecordingToolbarProps> = ({
+  darkMode = true,
+  isListening,
+  onToggleListening,
+  mode,
+  onChangeMode,
+  microphones,
+  selectedMicrophoneId,
+  onSelectMicrophone,
+  onRefreshMicrophones,
+  compact = false,
+  variant = 'full',
+}) => {
+  const dk = darkMode
+  const btnSize = compact ? 'w-14 h-14' : 'w-20 h-20'
+  const iconMic = compact ? 24 : 32
+  const iconSq = compact ? 20 : 26
+  const showModeAndMic = variant === 'full'
+
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <AnimatePresence mode="wait">
+        {isListening ? (
+          <motion.button
+            key="stop"
+            onClick={onToggleListening}
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.8, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 22 }}
+            whileTap={{ scale: 0.92 }}
+            className={`${btnSize} rounded-full flex items-center justify-center relative shadow-2xl bg-red-500 hover:bg-red-400 text-white shadow-red-500/30`}
+            title="録音を中断"
+          >
+            <span className="absolute inset-0 rounded-full bg-red-400 animate-ping opacity-25 pointer-events-none" />
+            <Square size={iconSq} fill="currentColor" />
+          </motion.button>
+        ) : (
+          <motion.button
+            key="start"
+            onClick={onToggleListening}
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.8, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 22 }}
+            whileTap={{ scale: 0.92 }}
+            className={`${btnSize} rounded-full flex items-center justify-center shadow-2xl ${
+              dk
+                ? 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/40'
+                : 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/30'
+            }`}
+            title="録音開始"
+          >
+            <Mic size={iconMic} />
+          </motion.button>
+        )}
+      </AnimatePresence>
+      <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
+        {isListening ? '中断' : '録音開始'}
+      </span>
+      {showModeAndMic ? (
+        <>
+          <div className="mt-0.5 flex flex-wrap items-center justify-center gap-1">
+            <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>モード</span>
+            <select
+              value={mode}
+              onChange={(e) => onChangeMode(e.target.value as TranscriptionMode)}
+              className={`max-w-[140px] rounded-md border px-1.5 py-0.5 text-[10px] ${
+                dk ? 'bg-slate-800 border-slate-700 text-slate-200' : 'bg-white border-slate-300 text-slate-700'
+              }`}
+              title="文字起こしモードを選択"
+            >
+              <option value="fast">速度重視</option>
+              <option value="accurate">正確さ重視</option>
+            </select>
+          </div>
+          <span className={`text-[9px] text-center px-1 ${dk ? 'text-slate-600' : 'text-slate-400'}`}>
+            {mode === 'fast' ? 'WebSpeechでリアルタイム寄り' : '停止後にローカルSTTで高精度化'}
+          </span>
+          <div className="mt-0.5 flex flex-wrap items-center justify-center gap-1">
+            <select
+              value={selectedMicrophoneId}
+              onChange={(e) => onSelectMicrophone(e.target.value)}
+              className={`max-w-[min(160px,100%)] rounded-md border px-1.5 py-0.5 text-[10px] ${
+                dk ? 'bg-slate-800 border-slate-700 text-slate-200' : 'bg-white border-slate-300 text-slate-700'
+              }`}
+              title="使用するマイクを選択"
+            >
+              {microphones.length === 0 && <option value="">利用可能マイクなし</option>}
+              {microphones.map((mic) => (
+                <option key={mic.deviceId} value={mic.deviceId}>
+                  {mic.label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={onRefreshMicrophones}
+              className={`rounded-md border px-1.5 py-0.5 text-[10px] font-bold ${
+                dk
+                  ? 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700'
+                  : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+              }`}
+              title="マイク一覧を再取得"
+            >
+              更新
+            </button>
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/Frontend/src/presentation/components/RecordingToolbar.tsx
+++ b/Frontend/src/presentation/components/RecordingToolbar.tsx
@@ -15,8 +15,8 @@ export type RecordingToolbarProps = {
   onRefreshMicrophones: () => void
   /** systemControl 内ではコンパクトに */
   compact?: boolean
-  /** 旧 App 等: 録音ボタンのみ */
-  variant?: 'full' | 'recordOnly'
+  /** 旧 App 等: 録音ボタンのみ / 操作ドック詳細: モード・マイクのみ */
+  variant?: 'full' | 'recordOnly' | 'controlsOnly'
 }
 
 export const RecordingToolbar: React.FC<RecordingToolbarProps> = ({
@@ -36,57 +36,63 @@ export const RecordingToolbar: React.FC<RecordingToolbarProps> = ({
   const btnSize = compact ? 'w-14 h-14' : 'w-20 h-20'
   const iconMic = compact ? 24 : 32
   const iconSq = compact ? 20 : 26
-  const showModeAndMic = variant === 'full'
+  const showModeAndMic = variant === 'full' || variant === 'controlsOnly'
+  const showRecordButton = variant !== 'controlsOnly'
 
   return (
-    <div className="flex flex-col items-center gap-1.5">
-      <AnimatePresence mode="wait">
-        {isListening ? (
-          <motion.button
-            key="stop"
-            onClick={onToggleListening}
-            initial={{ scale: 0.8, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            exit={{ scale: 0.8, opacity: 0 }}
-            transition={{ type: 'spring', stiffness: 300, damping: 22 }}
-            whileTap={{ scale: 0.92 }}
-            className={`${btnSize} rounded-full flex items-center justify-center relative shadow-2xl bg-red-500 hover:bg-red-400 text-white shadow-red-500/30`}
-            title="録音を中断"
-          >
-            <span className="absolute inset-0 rounded-full bg-red-400 animate-ping opacity-25 pointer-events-none" />
-            <Square size={iconSq} fill="currentColor" />
-          </motion.button>
-        ) : (
-          <motion.button
-            key="start"
-            onClick={onToggleListening}
-            initial={{ scale: 0.8, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            exit={{ scale: 0.8, opacity: 0 }}
-            transition={{ type: 'spring', stiffness: 300, damping: 22 }}
-            whileTap={{ scale: 0.92 }}
-            className={`${btnSize} rounded-full flex items-center justify-center shadow-2xl ${
-              dk
-                ? 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/40'
-                : 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/30'
-            }`}
-            title="録音開始"
-          >
-            <Mic size={iconMic} />
-          </motion.button>
-        )}
-      </AnimatePresence>
-      <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
-        {isListening ? '中断' : '録音開始'}
-      </span>
-      {showModeAndMic ? (
+    <div className="flex w-full flex-col items-center gap-1.5">
+      {showRecordButton ? (
         <>
-          <div className="mt-0.5 flex flex-wrap items-center justify-center gap-1">
+          <AnimatePresence mode="wait">
+            {isListening ? (
+              <motion.button
+                key="stop"
+                onClick={onToggleListening}
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0.8, opacity: 0 }}
+                transition={{ type: 'spring', stiffness: 300, damping: 22 }}
+                whileTap={{ scale: 0.92 }}
+                className={`${btnSize} rounded-full flex items-center justify-center relative shadow-2xl bg-red-500 hover:bg-red-400 text-white shadow-red-500/30`}
+                title="録音を中断"
+              >
+                <span className="absolute inset-0 rounded-full bg-red-400 animate-ping opacity-25 pointer-events-none" />
+                <Square size={iconSq} fill="currentColor" />
+              </motion.button>
+            ) : (
+              <motion.button
+                key="start"
+                onClick={onToggleListening}
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0.8, opacity: 0 }}
+                transition={{ type: 'spring', stiffness: 300, damping: 22 }}
+                whileTap={{ scale: 0.92 }}
+                className={`${btnSize} rounded-full flex items-center justify-center shadow-2xl ${
+                  dk
+                    ? 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/40'
+                    : 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/30'
+                }`}
+                title="録音開始"
+              >
+                <Mic size={iconMic} />
+              </motion.button>
+            )}
+          </AnimatePresence>
+          <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
+            {isListening ? '中断' : '録音開始'}
+          </span>
+        </>
+      ) : null}
+      {showModeAndMic ? (
+        <div className={`${showRecordButton ? 'mt-3' : 'mt-0'} flex w-full flex-col gap-2`}>
+          {/* Mode selector */}
+          <div className="flex flex-col gap-0.5">
             <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>モード</span>
             <select
               value={mode}
               onChange={(e) => onChangeMode(e.target.value as TranscriptionMode)}
-              className={`max-w-[140px] rounded-md border px-1.5 py-0.5 text-[10px] ${
+              className={`w-full rounded-md border px-2 py-1 text-[11px] ${
                 dk ? 'bg-slate-800 border-slate-700 text-slate-200' : 'bg-white border-slate-300 text-slate-700'
               }`}
               title="文字起こしモードを選択"
@@ -94,40 +100,45 @@ export const RecordingToolbar: React.FC<RecordingToolbarProps> = ({
               <option value="fast">速度重視</option>
               <option value="accurate">正確さ重視</option>
             </select>
+            <span className={`text-[9px] px-0.5 ${dk ? 'text-slate-600' : 'text-slate-400'}`}>
+              {mode === 'fast' ? 'WebSpeechでリアルタイム寄り' : '停止後にローカルSTTで高精度化'}
+            </span>
           </div>
-          <span className={`text-[9px] text-center px-1 ${dk ? 'text-slate-600' : 'text-slate-400'}`}>
-            {mode === 'fast' ? 'WebSpeechでリアルタイム寄り' : '停止後にローカルSTTで高精度化'}
-          </span>
-          <div className="mt-0.5 flex flex-wrap items-center justify-center gap-1">
-            <select
-              value={selectedMicrophoneId}
-              onChange={(e) => onSelectMicrophone(e.target.value)}
-              className={`max-w-[min(160px,100%)] rounded-md border px-1.5 py-0.5 text-[10px] ${
-                dk ? 'bg-slate-800 border-slate-700 text-slate-200' : 'bg-white border-slate-300 text-slate-700'
-              }`}
-              title="使用するマイクを選択"
-            >
-              {microphones.length === 0 && <option value="">利用可能マイクなし</option>}
-              {microphones.map((mic) => (
-                <option key={mic.deviceId} value={mic.deviceId}>
-                  {mic.label}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              onClick={onRefreshMicrophones}
-              className={`rounded-md border px-1.5 py-0.5 text-[10px] font-bold ${
-                dk
-                  ? 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700'
-                  : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
-              }`}
-              title="マイク一覧を再取得"
-            >
-              更新
-            </button>
+
+          {/* Microphone selector */}
+          <div className="flex flex-col gap-0.5">
+            <span className={`text-[10px] font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>マイク</span>
+            <div className="flex gap-1">
+              <select
+                value={selectedMicrophoneId}
+                onChange={(e) => onSelectMicrophone(e.target.value)}
+                className={`min-w-0 flex-1 rounded-md border px-2 py-1 text-[11px] ${
+                  dk ? 'bg-slate-800 border-slate-700 text-slate-200' : 'bg-white border-slate-300 text-slate-700'
+                }`}
+                title="使用するマイクを選択"
+              >
+                {microphones.length === 0 && <option value="">利用可能マイクなし</option>}
+                {microphones.map((mic) => (
+                  <option key={mic.deviceId} value={mic.deviceId}>
+                    {mic.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={onRefreshMicrophones}
+                className={`shrink-0 rounded-md border px-2 py-1 text-[10px] font-bold ${
+                  dk
+                    ? 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700'
+                    : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+                }`}
+                title="マイク一覧を再取得"
+              >
+                更新
+              </button>
+            </div>
           </div>
-        </>
+        </div>
       ) : null}
     </div>
   )

--- a/Frontend/src/presentation/components/TestFeaturesPopover.tsx
+++ b/Frontend/src/presentation/components/TestFeaturesPopover.tsx
@@ -71,14 +71,14 @@ export const TestFeaturesPopover: React.FC<Props> = ({ darkMode = true, align = 
         type="button"
         onClick={() => setOpen(v => !v)}
         title="開発者向けテスト（デモ・検証）"
-        className={`flex size-9 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${dk
+        className={`flex size-10 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${dk
           ? 'bg-amber-500/15 text-amber-400 hover:bg-amber-500/25 border border-amber-500/30'
           : 'bg-amber-50 text-amber-800 hover:bg-amber-100 border border-amber-200'}`}
         aria-expanded={open}
         aria-haspopup="dialog"
         aria-label="開発者向けテストを開く"
       >
-        <FlaskConical size={16} strokeWidth={2} />
+        <FlaskConical size={17} strokeWidth={2} />
       </button>
 
       {open && (

--- a/Frontend/src/presentation/constants/systemControlWindow.ts
+++ b/Frontend/src/presentation/constants/systemControlWindow.ts
@@ -1,2 +1,9 @@
 /** 操作パネル（削除不可の専用ウィンドウ）のレイアウト上の ID */
 export const SYSTEM_CONTROL_WINDOW_ID = 'systemControl' as const
+
+/**
+ * 操作ウィンドウがレイアウト上で確保する最小サイズ（px）。
+ * これより狭い／低いと主要ボタンが潰れるため、分割ペインとウィンドウ本体の双方で下限を張る。
+ */
+export const SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX = 156
+export const SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX = 196

--- a/Frontend/src/presentation/constants/systemControlWindow.ts
+++ b/Frontend/src/presentation/constants/systemControlWindow.ts
@@ -1,0 +1,2 @@
+/** 操作パネル（削除不可の専用ウィンドウ）のレイアウト上の ID */
+export const SYSTEM_CONTROL_WINDOW_ID = 'systemControl' as const

--- a/Frontend/src/presentation/context/PresentationShellContext.tsx
+++ b/Frontend/src/presentation/context/PresentationShellContext.tsx
@@ -1,0 +1,24 @@
+import React, { createContext, useContext } from 'react'
+
+export type PresentationShellValue = {
+  onOpenAppearance: () => void
+  onResetAll: () => void
+}
+
+const PresentationShellContext = createContext<PresentationShellValue | null>(null)
+
+export function PresentationShellProvider({
+  value,
+  children,
+}: {
+  value: PresentationShellValue
+  children: React.ReactNode
+}) {
+  return <PresentationShellContext.Provider value={value}>{children}</PresentationShellContext.Provider>
+}
+
+export function usePresentationShell(): PresentationShellValue {
+  const v = useContext(PresentationShellContext)
+  if (!v) throw new Error('usePresentationShell must be used within PresentationShellProvider')
+  return v
+}

--- a/Frontend/src/presentation/layout/LayoutEngine.tsx
+++ b/Frontend/src/presentation/layout/LayoutEngine.tsx
@@ -3,6 +3,11 @@ import { GripHorizontal, X } from 'lucide-react'
 import type { DropZone, LayoutNode } from '../../domain/entities/Layout'
 import { movePanel, updateRatio } from './layoutUtils'
 import { getWindowDefinition } from '../windows/registry'
+import {
+  SYSTEM_CONTROL_WINDOW_ID,
+  SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
+  SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
+} from '../constants/systemControlWindow'
 
 const ACCENT_RGB: Record<string, string> = {
   blue: '59,130,246',
@@ -124,13 +129,21 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
       const WindowComponent = def?.component
       const closable = def?.closable !== false
       const isTarget = dragging !== null && dragging !== node.windowId && dropInfo?.windowId === node.windowId
+      const isSystemControl = node.windowId === SYSTEM_CONTROL_WINDOW_ID
+      const leafMin: React.CSSProperties = isSystemControl
+        ? {
+            minWidth: SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
+            minHeight: SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
+          }
+        : { minWidth: 0, minHeight: 0 }
       return (
         <div
           key={node.id}
           style={{
             position: 'relative', display: 'flex', flexDirection: 'column',
-            width: '100%', height: '100%', minWidth: 0, minHeight: 0,
+            width: '100%', height: '100%',
             overflow: 'hidden', border: borderStyle, borderRadius: 6,
+            ...leafMin,
           }}
         >
           <div
@@ -179,9 +192,25 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
     }
 
     const isH = node.direction === 'h'
+    const isSystemControlDockPane = isH && node.a.type === 'leaf' && node.a.windowId === SYSTEM_CONTROL_WINDOW_ID
     const aStyle: React.CSSProperties = isH
-      ? { width: `${node.ratio * 100}%`, flexShrink: 0, flexGrow: 0, minWidth: 0, overflow: 'hidden', display: 'flex' }
-      : { height: `${node.ratio * 100}%`, flexShrink: 0, flexGrow: 0, minHeight: 0, overflow: 'hidden', display: 'flex' }
+      ? {
+          width: `${node.ratio * 100}%`,
+          flexShrink: 0,
+          flexGrow: 0,
+          minWidth: isSystemControlDockPane ? SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX : 0,
+          minHeight: isSystemControlDockPane ? SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX : 0,
+          overflow: 'hidden',
+          display: 'flex',
+        }
+      : {
+          height: `${node.ratio * 100}%`,
+          flexShrink: 0,
+          flexGrow: 0,
+          minHeight: 0,
+          overflow: 'hidden',
+          display: 'flex',
+        }
     const bStyle: React.CSSProperties = { flex: 1, minWidth: 0, minHeight: 0, overflow: 'hidden', display: 'flex' }
 
     return (

--- a/Frontend/src/presentation/layout/LayoutEngine.tsx
+++ b/Frontend/src/presentation/layout/LayoutEngine.tsx
@@ -122,6 +122,7 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
       const def = getWindowDefinition(node.windowId)
       const label = def?.label ?? node.windowId
       const WindowComponent = def?.component
+      const closable = def?.closable !== false
       const isTarget = dragging !== null && dragging !== node.windowId && dropInfo?.windowId === node.windowId
       return (
         <div
@@ -142,7 +143,7 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
             <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: dotColor }} />
             <GripHorizontal size={10} className="opacity-40 flex-shrink-0" />
             <span className="text-[9px] font-bold uppercase tracking-[0.15em]">{label}</span>
-            {onClose && (
+            {onClose && closable && (
               <button
                 onClick={e => { e.stopPropagation(); onClose(node.windowId) }}
                 className={`ml-auto p-0.5 rounded transition-colors ${darkMode ? 'hover:bg-slate-700 hover:text-white' : 'hover:bg-slate-200 hover:text-black'}`}

--- a/Frontend/src/presentation/layout/layoutUtils.ts
+++ b/Frontend/src/presentation/layout/layoutUtils.ts
@@ -7,7 +7,7 @@ const S = (direction: 'h' | 'v', ratio: number, a: LayoutNode, b: LayoutNode): S
   ({ type: 'split', id: newNodeId(), direction, ratio, a, b })
 
 /** 左列に削除不可の操作ウィンドウを付与する（発表中レイアウト用） */
-export function attachSystemControlDock(inner: LayoutNode, dockRatio = 0.16): LayoutNode {
+export function attachSystemControlDock(inner: LayoutNode, dockRatio = 0.17): LayoutNode {
   return S('h', dockRatio, L(SYSTEM_CONTROL_WINDOW_ID), inner)
 }
 

--- a/Frontend/src/presentation/layout/layoutUtils.ts
+++ b/Frontend/src/presentation/layout/layoutUtils.ts
@@ -1,34 +1,50 @@
 import type { DropZone, LeafNode, LayoutNode, SplitNode } from '../../domain/entities/Layout'
 import { newNodeId } from '../../domain/entities/Layout'
+import { SYSTEM_CONTROL_WINDOW_ID } from '../constants/systemControlWindow'
 
 const L = (windowId: string): LeafNode => ({ type: 'leaf', id: newNodeId(), windowId })
 const S = (direction: 'h' | 'v', ratio: number, a: LayoutNode, b: LayoutNode): SplitNode =>
   ({ type: 'split', id: newNodeId(), direction, ratio, a, b })
 
+/** 左列に削除不可の操作ウィンドウを付与する（発表中レイアウト用） */
+export function attachSystemControlDock(inner: LayoutNode, dockRatio = 0.16): LayoutNode {
+  return S('h', dockRatio, L(SYSTEM_CONTROL_WINDOW_ID), inner)
+}
+
 // ── 発表中フェーズのデフォルトレイアウト ──
 export const makeDefaultLayout = (): LayoutNode =>
-  S(
-    'h',
-    0.36,
-    L('transcription'),
-    S('h', 0.54, L('bubbleCloud'), S('v', 0.44, L('detail'), S('v', 0.5, L('importanceRanking'), L('history')))),
+  attachSystemControlDock(
+    S(
+      'h',
+      0.36,
+      L('transcription'),
+      S('h', 0.54, L('bubbleCloud'), S('v', 0.44, L('detail'), S('v', 0.5, L('importanceRanking'), L('history')))),
+    ),
   )
 
 export const makeLeftRightLayout = (): LayoutNode =>
-  S('h', 0.4, L('transcription'), S('v', 0.38, L('bubbleCloud'), S('h', 0.5, L('detail'), S('v', 0.5, L('importanceRanking'), L('history')))))
+  attachSystemControlDock(
+    S('h', 0.4, L('transcription'), S('v', 0.38, L('bubbleCloud'), S('h', 0.5, L('detail'), S('v', 0.5, L('importanceRanking'), L('history'))))),
+  )
 
 export const make2x2Layout = (): LayoutNode =>
-  S('v', 0.5, S('h', 0.5, L('transcription'), L('bubbleCloud')), S('h', 0.5, L('detail'), S('v', 0.5, L('importanceRanking'), L('history'))))
+  attachSystemControlDock(
+    S('v', 0.5, S('h', 0.5, L('transcription'), L('bubbleCloud')), S('h', 0.5, L('detail'), S('v', 0.5, L('importanceRanking'), L('history')))),
+  )
 
 export const makeHorizontalLayout = (): LayoutNode =>
-  S('h', 0.24, L('transcription'), S('h', 0.316, L('bubbleCloud'), S('h', 0.5, L('detail'), S('v', 0.5, L('importanceRanking'), L('history')))))
+  attachSystemControlDock(
+    S('h', 0.24, L('transcription'), S('h', 0.316, L('bubbleCloud'), S('h', 0.5, L('detail'), S('v', 0.5, L('importanceRanking'), L('history'))))),
+  )
 
 export const makeVerticalLayout = (): LayoutNode =>
-  S('v', 0.22, L('transcription'), S('v', 0.32, L('bubbleCloud'), S('v', 0.5, L('detail'), S('v', 0.5, L('importanceRanking'), L('history')))))
+  attachSystemControlDock(
+    S('v', 0.22, L('transcription'), S('v', 0.32, L('bubbleCloud'), S('v', 0.5, L('detail'), S('v', 0.5, L('importanceRanking'), L('history'))))),
+  )
 
 // ── 発表後フェーズのデフォルトレイアウト ──
 export const makeAfterLayout = (): LayoutNode =>
-  L('minutes')
+  attachSystemControlDock(L('minutes'), 0.22)
 
 // ── ツリー操作 ──
 

--- a/Frontend/src/presentation/layout/layoutUtils.ts
+++ b/Frontend/src/presentation/layout/layoutUtils.ts
@@ -7,7 +7,7 @@ const S = (direction: 'h' | 'v', ratio: number, a: LayoutNode, b: LayoutNode): S
   ({ type: 'split', id: newNodeId(), direction, ratio, a, b })
 
 /** 左列に削除不可の操作ウィンドウを付与する（発表中レイアウト用） */
-export function attachSystemControlDock(inner: LayoutNode, dockRatio = 0.17): LayoutNode {
+export function attachSystemControlDock(inner: LayoutNode, dockRatio = 0.18): LayoutNode {
   return S('h', dockRatio, L(SYSTEM_CONTROL_WINDOW_ID), inner)
 }
 

--- a/Frontend/src/presentation/phases/AfterPresentation/index.tsx
+++ b/Frontend/src/presentation/phases/AfterPresentation/index.tsx
@@ -3,6 +3,7 @@ import { LayoutEngine } from '../../layout/LayoutEngine'
 import { useLayoutStore } from '../../../stores/layoutStore'
 import { makeAfterLayout, removeLeaf } from '../../layout/layoutUtils'
 import type { LayoutNode } from '../../../domain/entities/Layout'
+import { SYSTEM_CONTROL_WINDOW_ID } from '../../constants/systemControlWindow'
 
 const PHASE_ID = 'after'
 
@@ -26,6 +27,7 @@ export const AfterPresentation: React.FC<Props> = ({ darkMode = true, themeColor
   }
 
   const handleClose = (windowId: string) => {
+    if (windowId === SYSTEM_CONTROL_WINDOW_ID) return
     const updated = removeLeaf(layout, windowId)
     if (updated) setLayout(PHASE_ID, updated)
   }

--- a/Frontend/src/presentation/phases/DuringPresentation/index.tsx
+++ b/Frontend/src/presentation/phases/DuringPresentation/index.tsx
@@ -4,6 +4,7 @@ import { useLayoutStore } from '../../../stores/layoutStore'
 import { makeDefaultLayout } from '../../layout/layoutUtils'
 import { removeLeaf } from '../../layout/layoutUtils'
 import type { LayoutNode } from '../../../domain/entities/Layout'
+import { SYSTEM_CONTROL_WINDOW_ID } from '../../constants/systemControlWindow'
 
 const PHASE_ID = 'during'
 
@@ -27,6 +28,7 @@ export const DuringPresentation: React.FC<Props> = ({ darkMode = true, themeColo
   }
 
   const handleClose = (windowId: string) => {
+    if (windowId === SYSTEM_CONTROL_WINDOW_ID) return
     const updated = removeLeaf(layout, windowId)
     if (updated) setLayout(PHASE_ID, updated)
   }

--- a/Frontend/src/presentation/windows/IWindowDefinition.ts
+++ b/Frontend/src/presentation/windows/IWindowDefinition.ts
@@ -9,4 +9,6 @@ export interface IWindowDefinition {
   id: string
   label: string
   component: React.ComponentType<WindowProps>
+  /** false のときレイアウトから閉じられない（閉じボタン非表示） */
+  closable?: boolean
 }

--- a/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
+++ b/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import { RotateCcw, Settings, RefreshCw } from 'lucide-react'
+import { LayoutPresetMenu } from '../../components/LayoutPresetMenu'
+import { TestFeaturesPopover } from '../../components/TestFeaturesPopover'
+import { PhaseTransitionButton } from '../../components/PhaseTransitionButton'
+import { RecordingToolbar } from '../../components/RecordingToolbar'
+import { usePresentationShell } from '../../context/PresentationShellContext'
+import { useTranscription } from '../../hooks/useTranscription'
+import { usePhaseStore } from '../../../stores/phaseStore'
+import type { WindowProps } from '../IWindowDefinition'
+
+const focusRing =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:ring-offset-2'
+
+export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
+  const { onOpenAppearance, onResetAll } = usePresentationShell()
+  const currentPhaseId = usePhaseStore(s => s.currentPhaseId)
+  const isDuring = currentPhaseId === 'during'
+  const dk = darkMode
+  const ringOffset = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
+
+  const {
+    isListening,
+    mode,
+    startListening,
+    stopListening,
+    setMode,
+    microphones,
+    selectedMicrophoneId,
+    refreshMicrophones,
+    selectMicrophone,
+  } = useTranscription()
+
+  const handleToggleListening = () => {
+    if (isListening) stopListening()
+    else startListening()
+  }
+
+  const settingsBtn = dk
+    ? 'text-slate-300 hover:bg-slate-800 hover:text-white'
+    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+
+  const resetBtn = dk
+    ? 'border border-amber-500/45 bg-amber-500/12 text-amber-300 hover:bg-amber-500/22 hover:border-amber-400/60'
+    : 'border border-amber-300/80 bg-amber-50 text-amber-900 hover:bg-amber-100 hover:border-amber-400'
+
+  const reloadBtn = dk
+    ? 'text-slate-300 hover:bg-slate-800 hover:text-white'
+    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+
+  return (
+    <div
+      className={`flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-3 ${dk ? 'bg-[#0d0e1a] text-slate-200' : 'bg-white text-slate-800'}`}
+    >
+      <div className={`text-[10px] font-black uppercase tracking-[0.2em] ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
+        操作
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-2 border-b pb-3 border-slate-700/40">
+        <RecordingToolbar
+          darkMode={darkMode}
+          isListening={isListening}
+          onToggleListening={handleToggleListening}
+          mode={mode}
+          onChangeMode={setMode}
+          microphones={microphones}
+          selectedMicrophoneId={selectedMicrophoneId}
+          onSelectMicrophone={selectMicrophone}
+          onRefreshMicrophones={refreshMicrophones}
+          compact
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <LayoutPresetMenu darkMode={darkMode} phaseId="during" menuAlign="left" disabled={!isDuring} />
+        <button
+          type="button"
+          onClick={onOpenAppearance}
+          title="設定"
+          className={`flex size-10 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${settingsBtn}`}
+          aria-haspopup="dialog"
+          aria-label="設定を開く"
+        >
+          <Settings size={18} strokeWidth={2} />
+        </button>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          title="アプリを再読み込み"
+          className={`flex size-10 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${reloadBtn}`}
+          aria-label="アプリを再読み込み"
+        >
+          <RefreshCw size={18} strokeWidth={2} />
+        </button>
+        <button
+          type="button"
+          onClick={onResetAll}
+          title="文字起こし・用語・履歴などをすべてクリアします"
+          className={`flex size-10 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${resetBtn}`}
+          aria-label="すべてのウィンドウをリセット"
+        >
+          <RotateCcw size={18} strokeWidth={2} />
+        </button>
+      </div>
+
+      {import.meta.env.DEV ? (
+        <div className={`flex justify-center border-b pb-3 ${dk ? 'border-slate-700/40' : 'border-slate-200'}`}>
+          <TestFeaturesPopover darkMode={darkMode} align="left" />
+        </div>
+      ) : null}
+
+      <div className="mt-auto flex justify-center pt-1">
+        <PhaseTransitionButton darkMode={darkMode} />
+      </div>
+    </div>
+  )
+}

--- a/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
+++ b/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
@@ -5,6 +5,10 @@ import { PhaseTransitionButton } from '../../components/PhaseTransitionButton'
 import { usePresentationShell } from '../../context/PresentationShellContext'
 import { useTranscription } from '../../hooks/useTranscription'
 import type { WindowProps } from '../IWindowDefinition'
+import {
+  SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
+  SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
+} from '../../constants/systemControlWindow'
 
 const focusRing =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:ring-offset-2'
@@ -24,15 +28,19 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
   const divider = dk ? 'bg-slate-700/40' : 'bg-slate-200'
 
   const recordBtnBase =
-    'relative flex min-h-10 h-10 min-w-0 flex-1 flex-row items-center justify-center gap-1.5 rounded-lg px-2 text-[10px] font-bold shadow-md'
+    'relative flex min-h-11 h-11 min-w-0 flex-1 flex-row items-center justify-center gap-2 rounded-lg px-2.5 text-[11px] font-bold shadow-md'
 
   return (
     <div
-      className={`flex h-full min-h-0 flex-col gap-1.5 overflow-y-auto p-2 ${
+      style={{
+        minWidth: SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
+        minHeight: SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
+      }}
+      className={`box-border flex h-full min-h-0 flex-col gap-2 overflow-y-auto p-2.5 ${
         dk ? 'bg-[#0d0e1a] text-slate-200' : 'bg-white text-slate-800'
       }`}
     >
-      <section aria-label="録音と発表の切り替え" className="flex gap-1.5">
+      <section aria-label="録音と発表の切り替え" className="flex gap-2">
         <AnimatePresence mode="wait">
           {isListening ? (
             <motion.button
@@ -47,7 +55,7 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
               title="録音を中断"
             >
               <span className="pointer-events-none absolute inset-0 animate-ping rounded-lg bg-red-400 opacity-15" />
-              <Square size={14} fill="currentColor" className="shrink-0" />
+              <Square size={16} fill="currentColor" className="shrink-0" />
               <span className="min-w-0 truncate">中断</span>
             </motion.button>
           ) : (
@@ -66,7 +74,7 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
               }`}
               title="録音開始"
             >
-              <Mic size={14} strokeWidth={2.25} className="shrink-0" />
+              <Mic size={16} strokeWidth={2.25} className="shrink-0" />
               <span className="min-w-0 truncate">録音</span>
             </motion.button>
           )}
@@ -81,14 +89,14 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
         type="button"
         onClick={onResetAll}
         title="文字起こし・用語・履歴などをすべてクリアします"
-        className={`flex w-full min-w-0 flex-row items-center justify-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11px] font-bold transition-colors ${
+        className={`flex w-full min-w-0 flex-row items-center justify-center gap-2 rounded-md border px-3 py-2 text-xs font-bold transition-colors ${
           dk
             ? 'border-amber-500/40 bg-amber-500/12 text-amber-300 hover:bg-amber-500/22'
             : 'border-amber-300/90 bg-amber-50 text-amber-900 hover:bg-amber-100'
         } ${focusRing} ${ringOffset}`}
         aria-label="すべてリセット"
       >
-        <RotateCcw size={13} strokeWidth={2.5} className="shrink-0" />
+        <RotateCcw size={15} strokeWidth={2.5} className="shrink-0" />
         リセット
       </button>
     </div>

--- a/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
+++ b/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
@@ -1,21 +1,16 @@
 import React from 'react'
 import { AnimatePresence, motion } from 'motion/react'
-import { Mic, Square, RotateCcw, Settings, RefreshCw } from 'lucide-react'
-import { LayoutPresetMenu } from '../../components/LayoutPresetMenu'
-import { TestFeaturesPopover } from '../../components/TestFeaturesPopover'
+import { Mic, Square, RotateCcw } from 'lucide-react'
 import { PhaseTransitionButton } from '../../components/PhaseTransitionButton'
 import { usePresentationShell } from '../../context/PresentationShellContext'
 import { useTranscription } from '../../hooks/useTranscription'
-import { usePhaseStore } from '../../../stores/phaseStore'
 import type { WindowProps } from '../IWindowDefinition'
 
 const focusRing =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:ring-offset-2'
 
 export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
-  const { onOpenAppearance, onResetAll } = usePresentationShell()
-  const currentPhaseId = usePhaseStore(s => s.currentPhaseId)
-  const isDuring = currentPhaseId === 'during'
+  const { onResetAll } = usePresentationShell()
   const dk = darkMode
   const ringOffset = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
 
@@ -27,9 +22,6 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
   }
 
   const divider = dk ? 'bg-slate-700/40' : 'bg-slate-200'
-  const tertiaryGhost = dk
-    ? 'text-slate-400 hover:bg-slate-800/90 hover:text-slate-100'
-    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-900'
 
   const recordBtnBase =
     'relative flex min-h-10 h-10 min-w-0 flex-1 flex-row items-center justify-center gap-1.5 rounded-lg px-2 text-[10px] font-bold shadow-md'
@@ -85,51 +77,20 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
 
       <div className={`h-px shrink-0 ${divider}`} role="presentation" />
 
-      <div className="flex min-w-0 items-center justify-between gap-2" aria-label="リセットとツール">
-        <button
-          type="button"
-          onClick={onResetAll}
-          title="文字起こし・用語・履歴などをすべてクリアします"
-          className={`flex shrink-0 flex-row items-center justify-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11px] font-bold transition-colors ${
-            dk
-              ? 'border-amber-500/40 bg-amber-500/12 text-amber-300 hover:bg-amber-500/22'
-              : 'border-amber-300/90 bg-amber-50 text-amber-900 hover:bg-amber-100'
-          } ${focusRing} ${ringOffset}`}
-          aria-label="すべてリセット"
-        >
-          <RotateCcw size={13} strokeWidth={2.5} className="shrink-0" />
-          リセット
-        </button>
-
-        <div className="flex shrink-0 items-center gap-1">
-          <LayoutPresetMenu darkMode={darkMode} phaseId="during" menuAlign="right" disabled={!isDuring} compact />
-          <button
-            type="button"
-            onClick={onOpenAppearance}
-            title="設定（表示・文字起こし・マイクなど）"
-            className={`flex size-8 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${tertiaryGhost}`}
-            aria-haspopup="dialog"
-            aria-label="設定を開く"
-          >
-            <Settings size={15} strokeWidth={2} />
-          </button>
-          <button
-            type="button"
-            onClick={() => window.location.reload()}
-            title="アプリを再読み込み"
-            className={`flex size-8 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${tertiaryGhost}`}
-            aria-label="アプリを再読み込み"
-          >
-            <RefreshCw size={14} strokeWidth={2} />
-          </button>
-        </div>
-      </div>
-
-      {import.meta.env.DEV ? (
-        <div className={`mt-auto border-t pt-1.5 ${dk ? 'border-slate-700/35' : 'border-slate-200'}`}>
-          <TestFeaturesPopover darkMode={darkMode} align="left" />
-        </div>
-      ) : null}
+      <button
+        type="button"
+        onClick={onResetAll}
+        title="文字起こし・用語・履歴などをすべてクリアします"
+        className={`flex w-full min-w-0 flex-row items-center justify-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11px] font-bold transition-colors ${
+          dk
+            ? 'border-amber-500/40 bg-amber-500/12 text-amber-300 hover:bg-amber-500/22'
+            : 'border-amber-300/90 bg-amber-50 text-amber-900 hover:bg-amber-100'
+        } ${focusRing} ${ringOffset}`}
+        aria-label="すべてリセット"
+      >
+        <RotateCcw size={13} strokeWidth={2.5} className="shrink-0" />
+        リセット
+      </button>
     </div>
   )
 }

--- a/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
+++ b/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { RotateCcw, Settings, RefreshCw } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import { Mic, Square, RotateCcw, Settings, RefreshCw } from 'lucide-react'
 import { LayoutPresetMenu } from '../../components/LayoutPresetMenu'
 import { TestFeaturesPopover } from '../../components/TestFeaturesPopover'
 import { PhaseTransitionButton } from '../../components/PhaseTransitionButton'
-import { RecordingToolbar } from '../../components/RecordingToolbar'
 import { usePresentationShell } from '../../context/PresentationShellContext'
 import { useTranscription } from '../../hooks/useTranscription'
 import { usePhaseStore } from '../../../stores/phaseStore'
@@ -19,99 +19,117 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
   const dk = darkMode
   const ringOffset = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
 
-  const {
-    isListening,
-    mode,
-    startListening,
-    stopListening,
-    setMode,
-    microphones,
-    selectedMicrophoneId,
-    refreshMicrophones,
-    selectMicrophone,
-  } = useTranscription()
+  const { isListening, startListening, stopListening } = useTranscription()
 
   const handleToggleListening = () => {
     if (isListening) stopListening()
     else startListening()
   }
 
-  const settingsBtn = dk
-    ? 'text-slate-300 hover:bg-slate-800 hover:text-white'
-    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+  const divider = dk ? 'bg-slate-700/40' : 'bg-slate-200'
+  const tertiaryGhost = dk
+    ? 'text-slate-400 hover:bg-slate-800/90 hover:text-slate-100'
+    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-900'
 
-  const resetBtn = dk
-    ? 'border border-amber-500/45 bg-amber-500/12 text-amber-300 hover:bg-amber-500/22 hover:border-amber-400/60'
-    : 'border border-amber-300/80 bg-amber-50 text-amber-900 hover:bg-amber-100 hover:border-amber-400'
-
-  const reloadBtn = dk
-    ? 'text-slate-300 hover:bg-slate-800 hover:text-white'
-    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+  const recordBtnBase =
+    'relative flex min-h-10 h-10 min-w-0 flex-1 flex-row items-center justify-center gap-1.5 rounded-lg px-2 text-[10px] font-bold shadow-md'
 
   return (
     <div
-      className={`flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-3 ${dk ? 'bg-[#0d0e1a] text-slate-200' : 'bg-white text-slate-800'}`}
+      className={`flex h-full min-h-0 flex-col gap-1.5 overflow-y-auto p-2 ${
+        dk ? 'bg-[#0d0e1a] text-slate-200' : 'bg-white text-slate-800'
+      }`}
     >
-      <div className={`text-[10px] font-black uppercase tracking-[0.2em] ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
-        操作
-      </div>
+      <section aria-label="録音と発表の切り替え" className="flex gap-1.5">
+        <AnimatePresence mode="wait">
+          {isListening ? (
+            <motion.button
+              key="stop"
+              onClick={handleToggleListening}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.12 }}
+              whileTap={{ scale: 0.98 }}
+              className={`${recordBtnBase} bg-red-500 text-white shadow-red-500/25 hover:bg-red-400`}
+              title="録音を中断"
+            >
+              <span className="pointer-events-none absolute inset-0 animate-ping rounded-lg bg-red-400 opacity-15" />
+              <Square size={14} fill="currentColor" className="shrink-0" />
+              <span className="min-w-0 truncate">中断</span>
+            </motion.button>
+          ) : (
+            <motion.button
+              key="start"
+              onClick={handleToggleListening}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.12 }}
+              whileTap={{ scale: 0.98 }}
+              className={`${recordBtnBase} ${
+                dk
+                  ? 'bg-indigo-600 text-white shadow-indigo-600/30 hover:bg-indigo-500'
+                  : 'bg-indigo-600 text-white shadow-indigo-600/25 hover:bg-indigo-500'
+              }`}
+              title="録音開始"
+            >
+              <Mic size={14} strokeWidth={2.25} className="shrink-0" />
+              <span className="min-w-0 truncate">録音</span>
+            </motion.button>
+          )}
+        </AnimatePresence>
 
-      <div className="flex flex-wrap items-center justify-center gap-2 border-b pb-3 border-slate-700/40">
-        <RecordingToolbar
-          darkMode={darkMode}
-          isListening={isListening}
-          onToggleListening={handleToggleListening}
-          mode={mode}
-          onChangeMode={setMode}
-          microphones={microphones}
-          selectedMicrophoneId={selectedMicrophoneId}
-          onSelectMicrophone={selectMicrophone}
-          onRefreshMicrophones={refreshMicrophones}
-          compact
-        />
-      </div>
+        <PhaseTransitionButton darkMode={darkMode} compact />
+      </section>
 
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <LayoutPresetMenu darkMode={darkMode} phaseId="during" menuAlign="left" disabled={!isDuring} />
-        <button
-          type="button"
-          onClick={onOpenAppearance}
-          title="設定"
-          className={`flex size-10 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${settingsBtn}`}
-          aria-haspopup="dialog"
-          aria-label="設定を開く"
-        >
-          <Settings size={18} strokeWidth={2} />
-        </button>
-        <button
-          type="button"
-          onClick={() => window.location.reload()}
-          title="アプリを再読み込み"
-          className={`flex size-10 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${reloadBtn}`}
-          aria-label="アプリを再読み込み"
-        >
-          <RefreshCw size={18} strokeWidth={2} />
-        </button>
+      <div className={`h-px shrink-0 ${divider}`} role="presentation" />
+
+      <div className="flex min-w-0 items-center justify-between gap-2" aria-label="リセットとツール">
         <button
           type="button"
           onClick={onResetAll}
           title="文字起こし・用語・履歴などをすべてクリアします"
-          className={`flex size-10 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${resetBtn}`}
-          aria-label="すべてのウィンドウをリセット"
+          className={`flex shrink-0 flex-row items-center justify-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11px] font-bold transition-colors ${
+            dk
+              ? 'border-amber-500/40 bg-amber-500/12 text-amber-300 hover:bg-amber-500/22'
+              : 'border-amber-300/90 bg-amber-50 text-amber-900 hover:bg-amber-100'
+          } ${focusRing} ${ringOffset}`}
+          aria-label="すべてリセット"
         >
-          <RotateCcw size={18} strokeWidth={2} />
+          <RotateCcw size={13} strokeWidth={2.5} className="shrink-0" />
+          リセット
         </button>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <LayoutPresetMenu darkMode={darkMode} phaseId="during" menuAlign="right" disabled={!isDuring} compact />
+          <button
+            type="button"
+            onClick={onOpenAppearance}
+            title="設定（表示・文字起こし・マイクなど）"
+            className={`flex size-8 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${tertiaryGhost}`}
+            aria-haspopup="dialog"
+            aria-label="設定を開く"
+          >
+            <Settings size={15} strokeWidth={2} />
+          </button>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            title="アプリを再読み込み"
+            className={`flex size-8 shrink-0 items-center justify-center rounded-full transition-colors ${focusRing} ${ringOffset} ${tertiaryGhost}`}
+            aria-label="アプリを再読み込み"
+          >
+            <RefreshCw size={14} strokeWidth={2} />
+          </button>
+        </div>
       </div>
 
       {import.meta.env.DEV ? (
-        <div className={`flex justify-center border-b pb-3 ${dk ? 'border-slate-700/40' : 'border-slate-200'}`}>
+        <div className={`mt-auto border-t pt-1.5 ${dk ? 'border-slate-700/35' : 'border-slate-200'}`}>
           <TestFeaturesPopover darkMode={darkMode} align="left" />
         </div>
       ) : null}
-
-      <div className="mt-auto flex justify-center pt-1">
-        <PhaseTransitionButton darkMode={darkMode} />
-      </div>
     </div>
   )
 }

--- a/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
+++ b/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
@@ -8,39 +8,17 @@ import type { Term } from '../../../domain/entities/Term'
 
 export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const demoStream = useDemoTools()
-  const {
-    transcript,
-    isListening,
-    mode,
-    startListening,
-    stopListening,
-    setMode,
-    microphones,
-    selectedMicrophoneId,
-    refreshMicrophones,
-    selectMicrophone,
-  } = useTranscription()
+  const { transcript, isListening } = useTranscription()
   const selectTerm = useTermStore(s => s.selectTerm)
   const togglePin = useTermStore(s => s.togglePin)
   const isPinned = useTermStore(s => s.pinnedTermIds)
   const activeTerms = useTermStore(s => s.activeTerms)
 
-  const handleToggleListening = () => {
-    if (isListening) stopListening()
-    else startListening()
-  }
-
   return (
     <TranscriptionView
       transcript={transcript}
       isListening={isListening}
-      mode={mode}
-      onChangeMode={setMode}
-      onToggleListening={handleToggleListening}
-      microphones={microphones}
-      selectedMicrophoneId={selectedMicrophoneId}
-      onRefreshMicrophones={refreshMicrophones}
-      onSelectMicrophone={selectMicrophone}
+      showRecordingCluster={false}
       showEmbeddedResetButton={false}
       onTermClick={(term: Term) => selectTerm(term)}
       onTermHover={() => {}}

--- a/Frontend/src/presentation/windows/index.ts
+++ b/Frontend/src/presentation/windows/index.ts
@@ -5,8 +5,16 @@ import { TermDetailWindow } from './TermDetailWindow'
 import { HistoryWindow } from './HistoryWindow'
 import { MinutesWindow } from './MinutesWindow'
 import { ImportanceRankingWindow } from './ImportanceRankingWindow'
+import { SystemControlWindow } from './SystemControlWindow'
+import { SYSTEM_CONTROL_WINDOW_ID } from '../constants/systemControlWindow'
 
 export function registerAllWindows(): void {
+  registerWindow({
+    id: SYSTEM_CONTROL_WINDOW_ID,
+    label: '操作',
+    component: SystemControlWindow,
+    closable: false,
+  })
   registerWindow({ id: 'transcription', label: '文字起こし', component: TranscriptionWindow })
   registerWindow({ id: 'bubbleCloud',   label: '用語マップ',  component: BubbleCloudWindow })
   registerWindow({ id: 'detail',        label: '詳細',        component: TermDetailWindow })


### PR DESCRIPTION
## 概要
プレゼンレイヤの操作 UI を整理し、操作ウィンドウ（systemControl）の使い勝手と下限サイズを確保します。

## 主な変更
- **操作ウィンドウ**: 録音・発表終了・リセットに集約。レイアウト／設定／テストはヘッダーへ移動。アプリ全体の `location.reload` は削除。
- **ヘッダー**: レイアウト（ラベル付き）・設定・DEV 時テストを右側に配置。
- **設定モーダル**: 文字起こしモード・マイク・一覧更新を集約。
- **レイアウト**: 操作ウィンドウ用の最小幅・最小高さを `LayoutEngine` と定数で保証。ドック既定比率 0.18。
- **その他**: `PresentationShellProvider`、`PhaseTransitionButton` / `LayoutPresetMenu` の調整、`ITranscriptionService.subscribe` 宣言など（積み上げコミット参照）。

## 確認してほしいこと
- [ ] 発表中のレイアウト変更・リセット・設定・録音の一連操作
- [ ] 狭いビューポートで操作ウィンドウが潰れないこと

Made with [Cursor](https://cursor.com)