### PR TITLE
feat(frontend): レイアウトメニューでウィンドウ表示を選択

### DIFF
--- a/Frontend/src/presentation/components/LayoutPresetMenu.tsx
+++ b/Frontend/src/presentation/components/LayoutPresetMenu.tsx
@@ -1,20 +1,26 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { LayoutGrid } from 'lucide-react'
 import { useLayoutStore } from '../../stores/layoutStore'
 import {
+  addUserWindowToDockedLayout,
+  attachSystemControlDock,
+  collectUserWindowIdsInLayout,
+  leafNode,
   makeDefaultLayout,
   makeLeftRightLayout,
   make2x2Layout,
   makeHorizontalLayout,
   makeVerticalLayout,
+  removeUserWindowFromDockedLayout,
 } from '../layout/layoutUtils'
+import { getLayoutSelectableWindows } from '../windows/registry'
 
 const PRESETS = [
-  { key: 'default',    label: 'デフォルト', make: makeDefaultLayout },
-  { key: 'leftRight',  label: '左右+縦分割', make: makeLeftRightLayout },
-  { key: '2x2',        label: '2×2',         make: make2x2Layout },
-  { key: 'horizontal', label: '横4列',        make: makeHorizontalLayout },
-  { key: 'vertical',   label: '縦4列',        make: makeVerticalLayout },
+  { key: 'default', label: 'デフォルト', make: makeDefaultLayout },
+  { key: 'leftRight', label: '左右+縦分割', make: makeLeftRightLayout },
+  { key: '2x2', label: '2×2', make: make2x2Layout },
+  { key: 'horizontal', label: '横4列', make: makeHorizontalLayout },
+  { key: 'vertical', label: '縦4列', make: makeVerticalLayout },
 ]
 
 interface Props {
@@ -41,14 +47,27 @@ export const LayoutPresetMenu: React.FC<Props> = ({
   compact = false,
   labeled = false,
 }) => {
+  const rootRef = useRef<HTMLDivElement>(null)
   const [open, setOpen] = useState(false)
   const setLayout = useLayoutStore(s => s.setLayout)
+  const layout = useLayoutStore(s => s.layouts[phaseId])
   const menuPos = menuAlign === 'right' ? 'right-0 left-auto' : 'left-0'
   const ringOffset = darkMode ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
 
   useEffect(() => {
     if (disabled) setOpen(false)
   }, [disabled])
+
+  useEffect(() => {
+    if (!open || disabled) return
+    const onPointerDown = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown, true)
+    return () => document.removeEventListener('pointerdown', onPointerDown, true)
+  }, [open, disabled])
 
   const toggle = () => {
     if (!disabled) setOpen(v => !v)
@@ -68,8 +87,31 @@ export const LayoutPresetMenu: React.FC<Props> = ({
     ? 'pointer-events-none cursor-not-allowed opacity-[0.42] saturate-50'
     : ''}`
 
+  const selectable = getLayoutSelectableWindows()
+  const activeIds = layout ? collectUserWindowIdsInLayout(layout) : new Set<string>()
+  const sortByLabel = (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label, 'ja')
+  const checkedDefs = selectable.filter(d => activeIds.has(d.id)).sort(sortByLabel)
+  const uncheckedDefs = selectable.filter(d => !activeIds.has(d.id)).sort(sortByLabel)
+  const orderedWindowRows = [...checkedDefs, ...uncheckedDefs]
+
+  const applyWindowToggle = (windowId: string, checked: boolean) => {
+    const cur = useLayoutStore.getState().layouts[phaseId]
+    if (checked) {
+      if (!cur) setLayout(phaseId, attachSystemControlDock(leafNode(windowId)))
+      else setLayout(phaseId, addUserWindowToDockedLayout(cur, windowId))
+    } else {
+      if (!cur) return
+      setLayout(phaseId, removeUserWindowFromDockedLayout(cur, windowId))
+    }
+  }
+
+  const dk = darkMode
+  const rowHover = dk ? 'hover:bg-slate-800/80' : 'hover:bg-slate-50'
+  const chk = dk ? 'accent-indigo-500 border-slate-600' : 'accent-indigo-600 border-slate-300'
+
   return (
     <div
+      ref={rootRef}
       className={`relative inline-flex ${labeled ? 'rounded-lg' : 'rounded-full'} ${disabled ? 'cursor-not-allowed' : ''}`}
       title={disabled ? '発表中のみレイアウトを変更できます' : undefined}
     >
@@ -77,9 +119,10 @@ export const LayoutPresetMenu: React.FC<Props> = ({
         type="button"
         disabled={disabled}
         onClick={toggle}
-        aria-label={disabled ? 'レイアウトプリセット（発表後は利用不可）' : 'レイアウトプリセットを開く'}
+        aria-label={disabled ? 'レイアウト（発表後は利用不可）' : 'レイアウトとウィンドウ'}
         aria-expanded={!disabled && open}
         aria-disabled={disabled}
+        aria-haspopup="true"
         className={labeled ? triggerLabeled : triggerIconOnly}
       >
         <LayoutGrid size={iconSize} strokeWidth={2} />
@@ -97,22 +140,55 @@ export const LayoutPresetMenu: React.FC<Props> = ({
       ) : null}
       {!disabled && open && (
         <div
-          className={`absolute top-full ${menuPos} mt-1 z-50 rounded-lg shadow-xl border py-1 min-w-[120px] ${darkMode
-            ? 'bg-[#0d0e1a] border-slate-700'
-            : 'bg-white border-slate-200'}`}
+          className={`absolute top-full ${menuPos} mt-1 z-[60] flex max-h-[min(70vh,420px)] w-[min(92vw,300px)] min-w-[260px] flex-col overflow-hidden rounded-lg border shadow-xl ${darkMode
+            ? 'border-slate-700 bg-[#0d0e1a]'
+            : 'border-slate-200 bg-white'}`}
+          role="menu"
         >
-          {PRESETS.map(p => (
-            <button
-              key={p.key}
-              type="button"
-              onClick={() => { setLayout(phaseId, p.make()); setOpen(false) }}
-              className={`w-full text-left px-3 py-1.5 text-xs transition-colors ${darkMode
-                ? 'text-slate-300 hover:bg-slate-800'
-                : 'text-slate-700 hover:bg-slate-50'}`}
-            >
-              {p.label}
-            </button>
-          ))}
+          <div className={`shrink-0 border-b px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wider ${dk ? 'border-slate-700 text-slate-500' : 'border-slate-200 text-slate-500'}`}>
+            ウィンドウ
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto py-1">
+            {orderedWindowRows.map(def => (
+              <label
+                key={def.id}
+                className={`flex cursor-pointer items-center justify-between gap-3 px-3 py-2 text-xs font-medium ${rowHover} ${dk ? 'text-slate-200' : 'text-slate-800'}`}
+              >
+                <span className="min-w-0 flex-1 truncate">{def.label}</span>
+                <input
+                  type="checkbox"
+                  className={`size-4 shrink-0 rounded border ${chk}`}
+                  checked={activeIds.has(def.id)}
+                  onChange={e => {
+                    e.stopPropagation()
+                    applyWindowToggle(def.id, e.target.checked)
+                  }}
+                  aria-label={`${def.label}を表示`}
+                />
+              </label>
+            ))}
+          </div>
+          <div className={`shrink-0 border-t px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wider ${dk ? 'border-slate-700 text-slate-500' : 'border-slate-200 text-slate-500'}`}>
+            レイアウトテンプレート
+          </div>
+          <div className="max-h-44 overflow-y-auto py-1">
+            {PRESETS.map(p => (
+              <button
+                key={p.key}
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setLayout(phaseId, p.make())
+                  setOpen(false)
+                }}
+                className={`w-full px-3 py-1.5 text-left text-xs transition-colors ${darkMode
+                  ? 'text-slate-300 hover:bg-slate-800'
+                  : 'text-slate-700 hover:bg-slate-50'}`}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/Frontend/src/presentation/layout/layoutUtils.ts
+++ b/Frontend/src/presentation/layout/layoutUtils.ts
@@ -81,3 +81,81 @@ export function updateRatio(node: LayoutNode, splitId: string, ratio: number): L
   if (node.id === splitId) return { ...node, ratio: Math.max(0.1, Math.min(0.9, ratio)) }
   return { ...node, a: updateRatio(node.a, splitId, ratio), b: updateRatio(node.b, splitId, ratio) }
 }
+
+// ── 操作ドック付きレイアウトのウィンドウ選択 ──
+
+const DEFAULT_SOLO_INNER_WINDOW = 'transcription'
+
+/** 左端が操作ウィンドウの横分割なら内側ツリーとドック比率を返す */
+export function tryUnwrapSystemControlDock(layout: LayoutNode): { dockRatio: number; inner: LayoutNode } | null {
+  if (layout.type !== 'split' || layout.direction !== 'h') return null
+  if (layout.a.type === 'leaf' && layout.a.windowId === SYSTEM_CONTROL_WINDOW_ID) {
+    return { dockRatio: layout.ratio, inner: layout.b }
+  }
+  return null
+}
+
+export function containsWindowId(node: LayoutNode, windowId: string): boolean {
+  if (node.type === 'leaf') return node.windowId === windowId
+  return containsWindowId(node.a, windowId) || containsWindowId(node.b, windowId)
+}
+
+/** レイアウトに含まれるユーザー領域のウィンドウ ID（操作ウィンドウ除く） */
+export function collectUserWindowIdsInLayout(layout: LayoutNode): Set<string> {
+  const ids = new Set<string>()
+  const walk = (n: LayoutNode) => {
+    if (n.type === 'leaf') {
+      if (n.windowId !== SYSTEM_CONTROL_WINDOW_ID) ids.add(n.windowId)
+    } else {
+      walk(n.a)
+      walk(n.b)
+    }
+  }
+  walk(layout)
+  return ids
+}
+
+/** 操作ウィンドウ以外で木の右側に近い葉の windowId（追加時の挿入基準） */
+export function findRightmostUserLeafWindowId(node: LayoutNode): string | null {
+  if (node.type === 'leaf') {
+    return node.windowId === SYSTEM_CONTROL_WINDOW_ID ? null : node.windowId
+  }
+  const r = findRightmostUserLeafWindowId(node.b)
+  if (r) return r
+  return findRightmostUserLeafWindowId(node.a)
+}
+
+function ensureNonEmptyInner(inner: LayoutNode | null): LayoutNode {
+  return inner ?? L(DEFAULT_SOLO_INNER_WINDOW)
+}
+
+/** ドック付きレイアウトからユーザー領域のウィンドウを 1 つ外す（内側が空なら文字起こしのみに戻す） */
+export function removeUserWindowFromDockedLayout(layout: LayoutNode, windowId: string): LayoutNode {
+  if (windowId === SYSTEM_CONTROL_WINDOW_ID) return layout
+  const un = tryUnwrapSystemControlDock(layout)
+  if (!un) {
+    const next = removeLeaf(layout, windowId)
+    return next ?? layout
+  }
+  const inner = ensureNonEmptyInner(removeLeaf(un.inner, windowId))
+  return attachSystemControlDock(inner, un.dockRatio)
+}
+
+/** ドック付きレイアウトのユーザー領域にウィンドウを追加（既にあればそのまま） */
+export function addUserWindowToDockedLayout(layout: LayoutNode, windowId: string): LayoutNode {
+  if (windowId === SYSTEM_CONTROL_WINDOW_ID) return layout
+  if (containsWindowId(layout, windowId)) return layout
+  const un = tryUnwrapSystemControlDock(layout)
+  if (!un) {
+    const target = findRightmostUserLeafWindowId(layout) ?? DEFAULT_SOLO_INNER_WINDOW
+    return insertLeaf(layout, target, windowId, 'right')
+  }
+  const target = findRightmostUserLeafWindowId(un.inner) ?? DEFAULT_SOLO_INNER_WINDOW
+  const inner = insertLeaf(un.inner, target, windowId, 'right')
+  return attachSystemControlDock(inner, un.dockRatio)
+}
+
+/** 単一ウィンドウの葉（レイアウト組み立て用） */
+export function leafNode(windowId: string): LeafNode {
+  return L(windowId)
+}

--- a/Frontend/src/presentation/windows/registry.ts
+++ b/Frontend/src/presentation/windows/registry.ts
@@ -1,4 +1,5 @@
 import type { IWindowDefinition } from './IWindowDefinition'
+import { SYSTEM_CONTROL_WINDOW_ID } from '../constants/systemControlWindow'
 
 const registry = new Map<string, IWindowDefinition>()
 
@@ -12,4 +13,11 @@ export function getWindowDefinition(id: string): IWindowDefinition | undefined {
 
 export function getAllWindowIds(): string[] {
   return [...registry.keys()]
+}
+
+/** レイアウト選択 UI 用（操作ウィンドウ除く・ラベル昇順） */
+export function getLayoutSelectableWindows(): IWindowDefinition[] {
+  return [...registry.values()]
+    .filter(d => d.id !== SYSTEM_CONTROL_WINDOW_ID)
+    .sort((a, b) => a.label.localeCompare(b.label, 'ja'))
 }


### PR DESCRIPTION
## 概要
レイアウトボタンから、操作ウィンドウ以外の各ウィンドウの表示／非表示をチェックで切り替えられるようにします。既存のレイアウトテンプレートはそのまま利用できます。

## 変更内容
- **レジストリ**: `getLayoutSelectableWindows()` で操作ウィンドウを除いた一覧をラベル昇順で取得。
- **layoutUtils**: 左ドック付きレイアウトを想定し、内側ツリーへのウィンドウ追加・削除（空時は文字起こしのみにフォールバック）、`leafNode` など。
- **LayoutPresetMenu**: ドロップダウン上部にウィンドウ一覧（チェック済みを上・未チェックを下）、下部に従来のテンプレート。外側クリックで閉じる。

## コミット
1. `feat(frontend): レイアウト用ウィンドウの追加・削除とレジストリ一覧`
2. `feat(frontend): レイアウトメニューにウィンドウ一覧とテンプレートを併記`

## 確認してほしいこと
- [ ] 発表中にチェックの ON/OFF でウィンドウが増減すること
- [ ] テンプレート選択で従来どおり全体レイアウトが適用されること
- [ ] メニュー外クリックで閉じること

Made with [Cursor](https://cursor.com)