### PR TITLE
feat(frontend): 用語・説明のコンテンツ向けフォントサイズ（設定スライダー）

### DIFF
--- a/Frontend/src/app/components/BubbleCloud.tsx
+++ b/Frontend/src/app/components/BubbleCloud.tsx
@@ -11,6 +11,8 @@ import {
   similarityToScore,
   MOCK_DIM,
 } from '../utils/mockVectors';
+import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
+import { scaledContentFontPx } from '../utils/contentFontScale';
 
 const CATEGORY_COLORS: Record<string, { bg: string; text: string; border: string; dot: string }> = {
   Frontend: { bg: 'bg-blue-500/20',    text: 'text-blue-300',    border: 'border-blue-500/30',    dot: '#60a5fa' },
@@ -67,6 +69,7 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
   onCategoryFilterChange,
 }) => {
   const dk = darkMode;
+  const contentFontScale = useContentFontScaleStore(s => s.scale);
   const categories = ['ALL', 'ピン中', ...Object.keys(CATEGORY_COLORS)];
 
   const dim = themeVector?.dim ?? MOCK_DIM;
@@ -364,13 +367,22 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
                               ? 'bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/35 border border-indigo-500/30'
                               : 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200'
                           }`}
+                          style={{ fontSize: scaledContentFontPx(12, contentFontScale) }}
                         >
                           {term.word}
                         </button>
                       </td>
-                      <td className={`py-2 px-3 text-xs ${dk ? 'text-slate-400' : 'text-slate-600'}`}>{term.category}</td>
+                      <td
+                        className={`py-2 px-3 ${dk ? 'text-slate-400' : 'text-slate-600'}`}
+                        style={{ fontSize: scaledContentFontPx(12, contentFontScale) }}
+                      >
+                        {term.category}
+                      </td>
                       <td className="py-2 px-3 max-w-[180px] align-top">
-                        <div className={`text-[11px] overflow-x-auto overflow-y-hidden whitespace-nowrap max-h-12 ${dk ? 'text-slate-500' : 'text-slate-500'}`}>
+                        <div
+                          className={`overflow-x-auto overflow-y-hidden whitespace-nowrap max-h-12 ${dk ? 'text-slate-500' : 'text-slate-500'}`}
+                          style={{ fontSize: scaledContentFontPx(11, contentFontScale) }}
+                        >
                           {term.shortDesc}
                         </div>
                       </td>
@@ -398,7 +410,7 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
         {activeTerms.length === 0 ? (
           <div className={`absolute inset-0 flex flex-col items-center justify-center ${dk ? 'text-slate-600' : 'text-slate-300'}`}>
             <Hexagon className="mb-3 opacity-30" size={40} />
-            <p className="text-xs font-bold opacity-60">用語抖出待機中</p>
+            <p className="text-xs font-bold opacity-60">用語検出待機中</p>
             <p className="text-[10px] opacity-40 mt-1">音声から検出された用語が<br />ここに表示されます</p>
           </div>
         ) : (

--- a/Frontend/src/app/components/HistoryPanel.tsx
+++ b/Frontend/src/app/components/HistoryPanel.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { Term } from '../data/terms';
 import { History, Trash2, ChevronRight, Search } from 'lucide-react';
+import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
+import { scaledContentFontPx } from '../utils/contentFontScale';
 
 const CATEGORY_DOT: Record<string, string> = {
   Frontend: '#60a5fa',
@@ -20,6 +22,7 @@ interface HistoryPanelProps {
 export const HistoryPanel: React.FC<HistoryPanelProps> = ({ history, onTermClick, onClear, darkMode = true }) => {
   const [search, setSearch] = useState('');
   const dk = darkMode;
+  const contentFontScale = useContentFontScaleStore(s => s.scale);
 
   const filtered = history.filter(t =>
     t.word.toLowerCase().includes(search.toLowerCase()) ||
@@ -75,8 +78,18 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({ history, onTermClick
                   style={{ background: CATEGORY_DOT[t.category] || '#94a3b8' }}
                 />
                 <div className="min-w-0 flex-1">
-                  <p className={`text-xs font-black truncate ${dk ? 'text-slate-200' : 'text-slate-700'}`}>{t.word}</p>
-                  <p className={`text-[10px] truncate ${dk ? 'text-slate-600' : 'text-slate-400'}`}>{t.shortDesc}</p>
+                  <p
+                    className={`font-black truncate ${dk ? 'text-slate-200' : 'text-slate-700'}`}
+                    style={{ fontSize: scaledContentFontPx(12, contentFontScale) }}
+                  >
+                    {t.word}
+                  </p>
+                  <p
+                    className={`truncate ${dk ? 'text-slate-600' : 'text-slate-400'}`}
+                    style={{ fontSize: scaledContentFontPx(10, contentFontScale) }}
+                  >
+                    {t.shortDesc}
+                  </p>
                 </div>
                 <ChevronRight size={12} className={dk ? 'text-slate-700 flex-shrink-0' : 'text-slate-300 flex-shrink-0'} />
               </button>

--- a/Frontend/src/app/components/SettingsModal.tsx
+++ b/Frontend/src/app/components/SettingsModal.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { Settings, X, Moon, Sun, Palette, SlidersHorizontal, Loader2, Mic } from 'lucide-react';
+import { Settings, X, Moon, Sun, Palette, SlidersHorizontal, Loader2, Mic, Type } from 'lucide-react';
 import { useTranscription } from '../../presentation/hooks/useTranscription';
 import type { TranscriptionMode } from '../../domain/interfaces/ITranscriptionService';
+import {
+  CONTENT_FONT_SCALE_MAX,
+  CONTENT_FONT_SCALE_MIN,
+  useContentFontScaleStore,
+} from '../../stores/contentFontScaleStore';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -46,6 +51,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   similarityReady = false,
 }) => {
   const { mode, setMode, microphones, selectedMicrophoneId, selectMicrophone, refreshMicrophones } = useTranscription();
+  const contentFontScale = useContentFontScaleStore(s => s.scale);
+  const setContentFontScale = useContentFontScaleStore(s => s.setScale);
 
   if (!isOpen) return null;
 
@@ -131,6 +138,34 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                     ))}
                   </div>
                 </div>
+              </section>
+
+              <section>
+                <div className={`flex items-center gap-1.5 mb-2.5 text-[10px] font-bold uppercase tracking-widest ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
+                  <Type size={12} /> 用語の表示
+                </div>
+                <div className="mb-1.5 flex items-center justify-between gap-2">
+                  <span className="text-xs font-bold">文字サイズ</span>
+                  <span className={`text-[10px] font-mono font-bold ${dk ? 'text-slate-400' : 'text-slate-500'}`}>
+                    {Math.round(contentFontScale * 100)}%
+                  </span>
+                </div>
+                <input
+                  type="range"
+                  min={Math.round(CONTENT_FONT_SCALE_MIN * 100)}
+                  max={Math.round(CONTENT_FONT_SCALE_MAX * 100)}
+                  step={5}
+                  value={Math.round(contentFontScale * 100)}
+                  onChange={(e) => setContentFontScale(Number(e.target.value) / 100)}
+                  className={`mb-1.5 w-full cursor-pointer accent-indigo-500 ${dk ? 'opacity-95' : ''}`}
+                  aria-valuemin={Math.round(CONTENT_FONT_SCALE_MIN * 100)}
+                  aria-valuemax={Math.round(CONTENT_FONT_SCALE_MAX * 100)}
+                  aria-valuenow={Math.round(contentFontScale * 100)}
+                  aria-label="用語と説明の文字サイズ"
+                />
+                <p className={`text-[10px] leading-snug ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
+                  各ウィンドウ内の重要語・説明文のみ拡大／縮小します。ウィンドウタイトルやこの設定画面の文字サイズは変わりません。
+                </p>
               </section>
 
               {/* 文字起こし（モード・マイク）— 操作ドックの詳細はここに集約 */}

--- a/Frontend/src/app/components/TermBubble.tsx
+++ b/Frontend/src/app/components/TermBubble.tsx
@@ -3,6 +3,8 @@ import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
 import { Term } from '../data/terms';
 import { Info, Star } from 'lucide-react';
+import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
+import { scaledContentFontPx } from '../utils/contentFontScale';
 
 const TOOLTIP = { W: 176, H: 120, PAD: 8, GAP_ABOVE: 12 } as const;
 
@@ -34,6 +36,7 @@ export const TermBubble: React.FC<TermBubbleProps> = ({
   intervalSec = 5,
   mapContainerRef,
 }) => {
+  const contentFontScale = useContentFontScaleStore(s => s.scale);
   const [isHovered, setIsHovered] = useState(false);
   const [isShowingDesc, setIsShowingDesc] = useState(false);
   const [tooltipPos, setTooltipPos] = useState<{ left: number; top: number; showBelow: boolean } | null>(null);
@@ -211,7 +214,12 @@ export const TermBubble: React.FC<TermBubbleProps> = ({
               className="absolute inset-0 flex items-center justify-center p-3 overflow-hidden rounded-full"
               title={term.shortDesc}
             >
-              <span className="line-clamp-4 overflow-hidden w-full leading-tight font-medium" style={{ fontSize: Math.min(10, Math.max(6, size * 0.13)) }}>
+              <span
+                className="line-clamp-4 overflow-hidden w-full leading-tight font-medium"
+                style={{
+                  fontSize: scaledContentFontPx(Math.min(10, Math.max(6, size * 0.13)), contentFontScale),
+                }}
+              >
                 {term.shortDesc}
               </span>
             </motion.div>
@@ -224,7 +232,12 @@ export const TermBubble: React.FC<TermBubbleProps> = ({
               transition={{ duration: 1, ease: "easeInOut" }}
               className="absolute inset-0 flex items-center justify-center p-2 overflow-hidden rounded-full"
             >
-              <span className="w-full" style={{ fontSize: Math.min(14, Math.max(7, size * 0.18)) }}>
+              <span
+                className="w-full"
+                style={{
+                  fontSize: scaledContentFontPx(Math.min(14, Math.max(7, size * 0.18)), contentFontScale),
+                }}
+              >
                 {term.word}
               </span>
             </motion.div>
@@ -269,17 +282,40 @@ export const TermBubble: React.FC<TermBubbleProps> = ({
           }}
         >
             <div className="flex items-center gap-1.5 mb-1">
-              <span className={`text-[9px] font-bold ${dk ? 'text-indigo-400' : 'text-indigo-500'}`}>{term.category}</span>
-              <span className={`text-[9px] ${dk ? 'text-slate-500' : 'text-slate-400'}`}>Lv.{term.level}</span>
+              <span
+                className={`font-bold ${dk ? 'text-indigo-400' : 'text-indigo-500'}`}
+                style={{ fontSize: scaledContentFontPx(9, contentFontScale) }}
+              >
+                {term.category}
+              </span>
+              <span
+                className={dk ? 'text-slate-500' : 'text-slate-400'}
+                style={{ fontSize: scaledContentFontPx(9, contentFontScale) }}
+              >
+                Lv.{term.level}
+              </span>
               {isPinned && (
-                <span className="text-[9px] font-bold text-yellow-400 flex items-center gap-0.5 ml-auto">
+                <span
+                  className="font-bold text-yellow-400 flex items-center gap-0.5 ml-auto"
+                  style={{ fontSize: scaledContentFontPx(9, contentFontScale) }}
+                >
                   <Star size={8} fill="currentColor" />ピン中
                 </span>
               )}
             </div>
-            <div className="text-xs font-bold mb-0.5">{term.word}</div>
-            <p className={`text-[10px] leading-relaxed line-clamp-2 ${dk ? 'text-slate-400' : 'text-slate-500'}`}>{term.shortDesc}</p>
-            <div className={`mt-1.5 text-[9px] font-medium flex items-center gap-1 ${dk ? 'text-indigo-400' : 'text-indigo-500'}`}>
+            <div className="font-bold mb-0.5" style={{ fontSize: scaledContentFontPx(12, contentFontScale) }}>
+              {term.word}
+            </div>
+            <p
+              className={`leading-relaxed line-clamp-2 ${dk ? 'text-slate-400' : 'text-slate-500'}`}
+              style={{ fontSize: scaledContentFontPx(10, contentFontScale) }}
+            >
+              {term.shortDesc}
+            </p>
+            <div
+              className={`mt-1.5 font-medium flex items-center gap-1 ${dk ? 'text-indigo-400' : 'text-indigo-500'}`}
+              style={{ fontSize: scaledContentFontPx(9, contentFontScale) }}
+            >
               <Info size={8} /> クリックで詳細
             </div>
             {/* 矢印：バブル中央に向けて指す（上向き or 下向き） */}

--- a/Frontend/src/app/components/TermDetailPanel.tsx
+++ b/Frontend/src/app/components/TermDetailPanel.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useCallback } from 'react';
 import { Term } from '../data/terms';
 import { X, ExternalLink, Hash, BookOpen, Layers, Star, Copy } from 'lucide-react';
+import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
+import { scaledContentFontPx } from '../utils/contentFontScale';
 
 interface TermDetailPanelProps {
   term: Term | null;
@@ -20,6 +22,7 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
   onTogglePin,
 }) => {
   const dk = darkMode;
+  const contentFontScale = useContentFontScaleStore(s => s.scale);
 
   if (!term) {
     return (
@@ -72,7 +75,9 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
               </span>
             </div>
             <div className="flex items-center gap-2 flex-wrap">
-              <h2 className="text-2xl font-black">{term.word}</h2>
+              <h2 className="font-black" style={{ fontSize: scaledContentFontPx(24, contentFontScale) }}>
+                {term.word}
+              </h2>
               <button
                 onClick={copyWord}
                 title="単語をコピー"
@@ -82,7 +87,12 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
               </button>
               {copied === 'word' && <span className="text-[10px] font-bold text-emerald-500">コピーしました</span>}
             </div>
-            <p className={`text-sm mt-0.5 ${dk ? 'text-slate-500' : 'text-slate-400'}`}>{term.kana}</p>
+            <p
+              className={`mt-0.5 ${dk ? 'text-slate-500' : 'text-slate-400'}`}
+              style={{ fontSize: scaledContentFontPx(14, contentFontScale) }}
+            >
+              {term.kana}
+            </p>
           </div>
           <div className="flex items-center gap-1 flex-shrink-0">
             {/* 星ボタン */}
@@ -134,7 +144,12 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
             </button>
           </div>
           {copied === 'desc' && <p className="text-[10px] font-bold text-emerald-500 mb-1">コピーしました</p>}
-          <p className={`text-sm leading-relaxed ${dk ? 'text-slate-300' : 'text-slate-600'}`}>{term.longDesc}</p>
+          <p
+            className={`leading-relaxed ${dk ? 'text-slate-300' : 'text-slate-600'}`}
+            style={{ fontSize: scaledContentFontPx(14, contentFontScale) }}
+          >
+            {term.longDesc}
+          </p>
         </section>
 
         {related.length > 0 && (

--- a/Frontend/src/app/components/TranscriptionView.tsx
+++ b/Frontend/src/app/components/TranscriptionView.tsx
@@ -7,6 +7,8 @@ import { Radio, Play, RotateCcw, FastForward, Pause, LoaderCircle, Star } from '
 import { UseDemoStreamReturn } from '../../debug/hooks/useDemoStream';
 import type { MicrophoneDevice, TranscriptionMode } from '../../domain/interfaces/ITranscriptionService';
 import { RecordingToolbar } from '../../presentation/components/RecordingToolbar';
+import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
+import { scaledContentFontPx } from '../utils/contentFontScale';
 
 const TOOLTIP = { W: 208, H: 100, PAD: 8, GAP_ABOVE: 12 } as const;
 
@@ -64,6 +66,7 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const termButtonRefs = useRef<Record<number, HTMLButtonElement | null>>({});
+  const contentFontScale = useContentFontScaleStore(s => s.scale);
   const [hoveredPartIndex, setHoveredPartIndex] = useState<number | null>(null);
   const [tooltipPos, setTooltipPos] = useState<{ left: number; top: number; showBelow: boolean } | null>(null);
 
@@ -206,7 +209,10 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
             )}
           </div>
         ) : (
-          <div className="whitespace-pre-wrap font-medium">
+          <div
+            className="whitespace-pre-wrap font-medium"
+            style={{ fontSize: scaledContentFontPx(14, contentFontScale) }}
+          >
             {parts.map((part, index) => {
               if (part.type === 'term') {
                 const term = part.term as Term;
@@ -264,11 +270,28 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
               </div>
             )}
             <div className="flex items-center gap-2 mb-1.5">
-              <span className={`text-[10px] font-bold ${dk ? 'text-indigo-400' : 'text-indigo-300'}`}>{hoveredTerm.category}</span>
-              <span className={`text-[10px] ${dk ? 'text-slate-500' : 'text-slate-400'}`}>Lv.{hoveredTerm.level}</span>
+              <span
+                className={`font-bold ${dk ? 'text-indigo-400' : 'text-indigo-300'}`}
+                style={{ fontSize: scaledContentFontPx(10, contentFontScale) }}
+              >
+                {hoveredTerm.category}
+              </span>
+              <span
+                className={dk ? 'text-slate-500' : 'text-slate-400'}
+                style={{ fontSize: scaledContentFontPx(10, contentFontScale) }}
+              >
+                Lv.{hoveredTerm.level}
+              </span>
             </div>
-            <div className="text-sm font-black mb-1">{hoveredTerm.word}</div>
-            <p className={`text-[11px] leading-relaxed line-clamp-2 ${dk ? 'text-slate-400' : 'text-slate-300'}`}>{hoveredTerm.shortDesc}</p>
+            <div className="font-black mb-1" style={{ fontSize: scaledContentFontPx(14, contentFontScale) }}>
+              {hoveredTerm.word}
+            </div>
+            <p
+              className={`leading-relaxed line-clamp-2 ${dk ? 'text-slate-400' : 'text-slate-300'}`}
+              style={{ fontSize: scaledContentFontPx(11, contentFontScale) }}
+            >
+              {hoveredTerm.shortDesc}
+            </p>
             <div
               className={`absolute left-1/2 -translate-x-1/2 border-[6px] border-transparent ${
                 tooltipPos.showBelow

--- a/Frontend/src/app/utils/contentFontScale.ts
+++ b/Frontend/src/app/utils/contentFontScale.ts
@@ -1,0 +1,4 @@
+/** 用語・説明文など「ウィンドウ内コンテンツ」向けの px をスケール（下限で潰れすぎ防止） */
+export function scaledContentFontPx(basePx: number, scale: number): number {
+  return Math.max(8, Math.round(basePx * scale))
+}

--- a/Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx
+++ b/Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx
@@ -11,6 +11,8 @@ import {
   type RankingSignal,
 } from '../../utils/importanceRanking'
 import type { WindowProps } from '../IWindowDefinition'
+import { useContentFontScaleStore } from '../../../stores/contentFontScaleStore'
+import { scaledContentFontPx } from '../../../app/utils/contentFontScale'
 
 const RANK_THROTTLE_MS = 160
 const MIN_ROW_HEIGHT = 50
@@ -30,13 +32,16 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
   const pinnedTermIds = useTermStore(s => s.pinnedTermIds)
   const togglePin = useTermStore(s => s.togglePin)
 
+  const contentFontScale = useContentFontScaleStore(s => s.scale)
+
   const throttledTranscript = useThrottledValue(transcript, RANK_THROTTLE_MS)
   const throttledTerms = useThrottledValue(activeTerms as Term[], RANK_THROTTLE_MS)
   const throttledWeights = useThrottledValue(termClickWeights, RANK_THROTTLE_MS)
   const rowHeight = Math.round(
     MIN_ROW_HEIGHT + (rowSizeSlider / 100) * (MAX_ROW_HEIGHT - MIN_ROW_HEIGHT),
   )
-  const wordFontSize = Math.round(15 + (rowSizeSlider / 100) * 12)
+  const wordFontSizeBase = Math.round(15 + (rowSizeSlider / 100) * 12)
+  const wordFontSize = scaledContentFontPx(wordFontSizeBase, contentFontScale)
 
   useEffect(() => {
     const el = containerRef.current
@@ -190,7 +195,10 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
                         >
                           {row.term.word}
                         </span>
-                        <span className={`block text-[10px] ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
+                        <span
+                          className={`block ${dk ? 'text-slate-500' : 'text-slate-400'}`}
+                          style={{ fontSize: scaledContentFontPx(10, contentFontScale) }}
+                        >
                           Lv.{row.term.level} / {row.term.category}
                         </span>
                         <span className={`mt-1 block h-1.5 w-full rounded-full ${dk ? 'bg-slate-700' : 'bg-slate-200'}`}>

--- a/Frontend/src/stores/contentFontScaleStore.ts
+++ b/Frontend/src/stores/contentFontScaleStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand'
+
+const STORAGE_KEY = 'talkscope.contentFontScale.v1'
+export const CONTENT_FONT_SCALE_MIN = 0.85
+export const CONTENT_FONT_SCALE_MAX = 1.35
+export const CONTENT_FONT_SCALE_DEFAULT = 1
+
+function clampScale(v: number): number {
+  return Math.round(Math.min(CONTENT_FONT_SCALE_MAX, Math.max(CONTENT_FONT_SCALE_MIN, v)) * 100) / 100
+}
+
+function readStored(): number {
+  if (typeof window === 'undefined') return CONTENT_FONT_SCALE_DEFAULT
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw == null) return CONTENT_FONT_SCALE_DEFAULT
+    const n = Number(raw)
+    return Number.isFinite(n) ? clampScale(n) : CONTENT_FONT_SCALE_DEFAULT
+  } catch {
+    return CONTENT_FONT_SCALE_DEFAULT
+  }
+}
+
+interface ContentFontScaleState {
+  scale: number
+  setScale: (v: number) => void
+}
+
+export const useContentFontScaleStore = create<ContentFontScaleState>((set) => ({
+  scale: typeof window !== 'undefined' ? readStored() : CONTENT_FONT_SCALE_DEFAULT,
+  setScale: (v) => {
+    const scale = clampScale(v)
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(scale))
+    } catch {
+      /* ignore */
+    }
+    set({ scale })
+  },
+}))


### PR DESCRIPTION
## 概要
設定モーダルに「用語の表示」スライダー（85%〜135%、5%刻み）を追加し、各ウィンドウ内の**用語と説明まわり**のフォントだけを拡大・縮小できるようにしました。ウィンドウのヘッダー／フッターや設定画面の見出しなどの UI 文字サイズは変えていません。

## 実装の要点
- `scaledContentFontPx` と `contentFontScaleStore`（`localStorage`: `talkscope.contentFontScale.v1`）でスケールを共有
- 対象: 文字起こし本文・用語ホバー、TermBubble、用語詳細（見出し・かな・長文）、履歴一覧、重要度ランキング行、用語マップのピン一覧表
- 空状態コピー: 「用語抖出」→「用語検出」の誤字修正（BubbleCloud）

## コミット
細かく 8 コミットに分割済み（ストア→設定 UI→各画面の順）。

## 確認
- `cd Frontend && bun run build` 成功

Made with [Cursor](https://cursor.com)