### PR TITLE
feat(frontend): アクセントカラーによるテーマ化とパネル背景の色付け

### DIFF
--- a/Frontend/src/app/App.tsx
+++ b/Frontend/src/app/App.tsx
@@ -28,6 +28,9 @@ import {
   makeLeftRightLayout,
   removeLeaf,
 } from './layout/layoutUtils';
+import { AccentThemeProvider } from '../theme/AccentThemeContext';
+import { accentRgba, micStartButtonStyle } from '../theme/accentStyles';
+import { getAccentRgb } from '../theme/accentTokens';
 
 
 
@@ -497,15 +500,24 @@ const App: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }), [transcript, isListening, filteredTerms, termWeights, termFrequencies, selectedTerm, searchHistory, dk, categoryFilter, handleTermClick, isPinned, handleTogglePin, themeVector, themeText, termVectors, apiTerms]);
 
+  const shellRgb = getAccentRgb(settings.themeColor);
+
   return (
+    <AccentThemeProvider themeColor={settings.themeColor}>
     <div
       className={`h-full flex flex-col font-sans transition-colors duration-500 ${dk ? 'bg-[#0a0b14] text-slate-100' : 'bg-slate-50 text-slate-900'}`}
       style={{ fontFamily: "'Segoe UI', system-ui, sans-serif" }}
     >
       {dk && (
         <div className="fixed inset-0 pointer-events-none z-0">
-          <div className="absolute top-0 left-1/4 w-96 h-96 bg-indigo-600/5 rounded-full blur-3xl" />
-          <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-violet-600/5 rounded-full blur-3xl" />
+          <div
+            className="absolute top-0 left-1/4 w-96 h-96 rounded-full blur-3xl"
+            style={{ backgroundColor: accentRgba(shellRgb, 0.12) }}
+          />
+          <div
+            className="absolute bottom-0 right-1/4 w-96 h-96 rounded-full blur-3xl"
+            style={{ backgroundColor: accentRgba(shellRgb, 0.08) }}
+          />
         </div>
       )}
 
@@ -516,11 +528,19 @@ const App: React.FC = () => {
         <div className="w-full min-w-0 px-4 h-14 flex items-center justify-between gap-4">
           {/* Logo */}
           <div className="flex items-center gap-3 shrink-0">
-            <div className="bg-indigo-600 p-1.5 rounded-xl text-white shadow-lg shadow-indigo-600/30">
+            <div
+              className="p-1.5 rounded-xl text-white shadow-lg transition-[filter] hover:brightness-110"
+              style={micStartButtonStyle(shellRgb, dk)}
+            >
               <Book size={18} />
             </div>
             <span className="text-lg font-black tracking-tight">TalkScope</span>
-            <span className="text-[9px] font-bold text-indigo-400 uppercase tracking-[0.2em] hidden sm:inline">Pro</span>
+            <span
+              className="text-[9px] font-bold uppercase tracking-[0.2em] hidden sm:inline"
+              style={{ color: accentRgba(shellRgb, dk ? 0.85 : 0.7) }}
+            >
+              Pro
+            </span>
           </div>
 
           {/* Actions（右詰め）: 主題 → レイアウト → API確認 → 設定 */}
@@ -549,7 +569,18 @@ const App: React.FC = () => {
             <div className="relative">
               <button
                 onClick={() => setIsLayoutMenuOpen(v => !v)}
-                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold border transition-all ${isLayoutMenuOpen ? (dk ? 'bg-indigo-600/20 border-indigo-500/50 text-indigo-300' : 'bg-indigo-50 border-indigo-200 text-indigo-600') : (dk ? 'text-slate-400 hover:text-slate-200 bg-slate-800/50 hover:bg-slate-800 border-slate-700/50' : 'text-slate-500 hover:text-slate-700 bg-white border-slate-200 hover:bg-slate-50')}`}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold border transition-all ${
+                  isLayoutMenuOpen ? '' : (dk ? 'text-slate-400 hover:text-slate-200 bg-slate-800/50 hover:bg-slate-800 border-slate-700/50' : 'text-slate-500 hover:text-slate-700 bg-white border-slate-200 hover:bg-slate-50')
+                }`}
+                style={
+                  isLayoutMenuOpen
+                    ? {
+                        backgroundColor: accentRgba(shellRgb, dk ? 0.22 : 0.1),
+                        borderColor: accentRgba(shellRgb, dk ? 0.5 : 0.35),
+                        color: accentRgba(shellRgb, dk ? 0.95 : 0.88),
+                      }
+                    : undefined
+                }
               >
                 <LayoutGrid size={13} />レイアウト
               </button>
@@ -561,7 +592,13 @@ const App: React.FC = () => {
                       <button
                         key={p.key}
                         onClick={() => { setLayout(p.make()); setIsLayoutMenuOpen(false); }}
-                        className={`w-full text-left px-4 py-2.5 text-xs font-bold transition-colors ${dk ? 'hover:bg-indigo-600/20 text-slate-300 hover:text-white' : 'hover:bg-indigo-50 text-slate-600 hover:text-indigo-700'}`}
+                        className={`w-full text-left px-4 py-2.5 text-xs font-bold transition-colors ${dk ? 'text-slate-300 hover:text-white' : 'text-slate-600 hover:text-slate-900'}`}
+                        onMouseEnter={(e) => {
+                          e.currentTarget.style.backgroundColor = accentRgba(shellRgb, dk ? 0.18 : 0.1);
+                        }}
+                        onMouseLeave={(e) => {
+                          e.currentTarget.style.backgroundColor = 'transparent';
+                        }}
                       >
                         {p.label}
                       </button>
@@ -630,6 +667,7 @@ const App: React.FC = () => {
         darkMode={dk}
       />
     </div>
+    </AccentThemeProvider>
   );
 };
 

--- a/Frontend/src/app/components/BubbleCloud.tsx
+++ b/Frontend/src/app/components/BubbleCloud.tsx
@@ -13,6 +13,8 @@ import {
 } from '../utils/mockVectors';
 import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
 import { scaledContentFontPx } from '../utils/contentFontScale';
+import { useAccentTheme } from '../../theme/AccentThemeContext';
+import { accentRgba, accentSliderStyle, micStartButtonStyle, termChipStyle } from '../../theme/accentStyles';
 
 const CATEGORY_COLORS: Record<string, { bg: string; text: string; border: string; dot: string }> = {
   Frontend: { bg: 'bg-blue-500/20',    text: 'text-blue-300',    border: 'border-blue-500/30',    dot: '#60a5fa' },
@@ -69,6 +71,7 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
   onCategoryFilterChange,
 }) => {
   const dk = darkMode;
+  const { rgb } = useAccentTheme();
   const contentFontScale = useContentFontScaleStore(s => s.scale);
   const categories = ['ALL', 'ピン中', ...Object.keys(CATEGORY_COLORS)];
 
@@ -318,7 +321,8 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
               step={0.1}
               value={bubbleScale}
               onChange={(e) => setBubbleScale(Number(e.target.value))}
-              className={`flex-1 h-1.5 rounded-full appearance-none cursor-pointer accent-indigo-500 min-w-0 ${dk ? 'bg-slate-700' : 'bg-slate-200'}`}
+              className={`flex-1 h-1.5 rounded-full appearance-none cursor-pointer min-w-0 ${dk ? 'bg-slate-700' : 'bg-slate-200'}`}
+              style={accentSliderStyle(rgb)}
             />
             <span className={`text-[10px] font-mono font-bold tabular-nums shrink-0 ${dk ? 'text-slate-400' : 'text-slate-600'}`}>
               {Math.round(bubbleScale * 100)}%
@@ -362,12 +366,11 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
                             e.preventDefault();
                             onTogglePin(term.id);
                           }}
-                          className={`px-1.5 py-0.5 rounded-md cursor-pointer transition-all font-bold text-left ${
-                            dk
-                              ? 'bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/35 border border-indigo-500/30'
-                              : 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200'
-                          }`}
-                          style={{ fontSize: scaledContentFontPx(12, contentFontScale) }}
+                          className="px-1.5 py-0.5 rounded-md cursor-pointer transition-[filter] font-bold text-left hover:brightness-110"
+                          style={{
+                            ...termChipStyle(dk, rgb),
+                            fontSize: scaledContentFontPx(12, contentFontScale),
+                          }}
                         >
                           {term.word}
                         </button>
@@ -473,7 +476,10 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
               >
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-black">切換え間隔</span>
-                  <span className={`text-lg font-black tabular-nums ${isAutoPlay ? 'text-indigo-400' : dk ? 'text-slate-400' : 'text-slate-500'}`}>
+                  <span
+                    className={`text-lg font-black tabular-nums ${isAutoPlay ? '' : dk ? 'text-slate-400' : 'text-slate-500'}`}
+                    style={isAutoPlay ? { color: accentRgba(rgb, dk ? 0.95 : 0.85) } : undefined}
+                  >
                     {intervalSec}<span className="text-xs font-bold ml-0.5">秒</span>
                   </span>
                 </div>
@@ -490,8 +496,11 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
                     disabled={activeTerms.length === 0}
                     className={`w-full h-2.5 rounded-full appearance-none cursor-pointer ${
                       activeTerms.length === 0 ? 'cursor-not-allowed opacity-40' : ''
-                    } ${isAutoPlay ? 'accent-indigo-500' : (dk ? 'accent-slate-500' : 'accent-slate-400')}`}
-                    style={{ background: dk ? '#1e293b' : '#e2e8f0' }}
+                    }`}
+                    style={{
+                      background: dk ? '#1e293b' : '#e2e8f0',
+                      ...(activeTerms.length === 0 ? {} : accentSliderStyle(rgb)),
+                    }}
                   />
                 </div>
 
@@ -512,7 +521,10 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
                   >
                     <ChevronDown size={14} className="mx-auto" />
                   </button>
-                  <span className={`text-xs font-mono font-black w-10 text-center ${isAutoPlay ? 'text-indigo-400' : dk ? 'text-slate-400' : 'text-slate-500'}`}>
+                  <span
+                    className={`text-xs font-mono font-black w-10 text-center ${isAutoPlay ? '' : dk ? 'text-slate-400' : 'text-slate-500'}`}
+                    style={isAutoPlay ? { color: accentRgba(rgb, dk ? 0.95 : 0.85) } : undefined}
+                  >
                     {intervalSec}s
                   </span>
                   <button
@@ -539,10 +551,17 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
                 whileHover={{ scale: 1.06 }}
                 title="間隔の設定"
                 className={`w-10 h-10 rounded-full flex items-center justify-center border-2 shadow-lg text-xs font-black transition-colors ${
-                  showSlider
-                    ? (dk ? 'bg-indigo-600/30 border-indigo-500/60 text-indigo-300' : 'bg-indigo-50 border-indigo-300 text-indigo-600')
-                    : (dk ? 'bg-slate-800 border-slate-600 text-slate-400 hover:border-slate-500' : 'bg-white border-slate-300 text-slate-500 hover:border-slate-400')
+                  showSlider ? '' : (dk ? 'bg-slate-800 border-slate-600 text-slate-400 hover:border-slate-500' : 'bg-white border-slate-300 text-slate-500 hover:border-slate-400')
                 }`}
+                style={
+                  showSlider
+                    ? {
+                        backgroundColor: accentRgba(rgb, dk ? 0.28 : 0.12),
+                        borderColor: accentRgba(rgb, dk ? 0.55 : 0.45),
+                        color: accentRgba(rgb, dk ? 0.95 : 0.9),
+                      }
+                    : undefined
+                }
               >
                 {intervalSec}s
               </motion.button>
@@ -553,24 +572,38 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
                 disabled={activeTerms.length === 0}
                 whileTap={{ scale: 0.92 }}
                 whileHover={{ scale: activeTerms.length === 0 ? 1 : 1.06 }}
-                className={`w-16 h-16 rounded-full flex items-center justify-center shadow-2xl relative transition-colors ${
+                className={`w-16 h-16 rounded-full flex items-center justify-center shadow-2xl relative transition-[filter] ${
                   activeTerms.length === 0
                     ? (dk ? 'bg-slate-800 border-2 border-slate-700 text-slate-700 cursor-not-allowed' : 'bg-slate-100 border-2 border-slate-200 text-slate-300 cursor-not-allowed')
                     : isAutoPlay
-                      ? (dk ? 'bg-indigo-600 text-white shadow-indigo-600/40 hover:bg-indigo-500' : 'bg-indigo-600 text-white shadow-indigo-500/30 hover:bg-indigo-500')
-                      : (dk ? 'bg-slate-800 border-2 border-slate-600 text-slate-300 hover:border-indigo-500/60 hover:text-indigo-300' : 'bg-white border-2 border-slate-300 text-slate-500 hover:border-indigo-400 hover:text-indigo-500')
+                      ? 'border-2 border-transparent text-white hover:brightness-110'
+                      : (dk ? 'bg-slate-800 border-2 border-slate-600 text-slate-300 cursor-pointer hover:brightness-110' : 'bg-white border-2 border-slate-300 text-slate-500 cursor-pointer hover:brightness-110')
                 }`}
+                style={
+                  activeTerms.length === 0
+                    ? undefined
+                    : isAutoPlay
+                      ? micStartButtonStyle(rgb, dk)
+                      : {
+                          borderColor: accentRgba(rgb, dk ? 0.48 : 0.35),
+                          color: accentRgba(rgb, dk ? 0.92 : 0.82),
+                        }
+                }
                 title={isAutoPlay ? '自動切換えを停止' : '自動切換えを開始'}
               >
                 {isAutoPlay && (
-                  <span className="absolute inset-0 rounded-full bg-indigo-400 animate-ping opacity-20 pointer-events-none" />
+                  <span
+                    className="absolute inset-0 rounded-full animate-ping opacity-20 pointer-events-none"
+                    style={{ backgroundColor: accentRgba(rgb, 0.45) }}
+                  />
                 )}
                 {isAutoPlay ? <Pause size={22} fill="currentColor" /> : <Shuffle size={22} />}
               </motion.button>
             </div>
-            <span className={`text-[10px] font-bold ${
-              isAutoPlay ? 'text-indigo-400' : dk ? 'text-slate-600' : 'text-slate-400'
-            }`}>
+            <span
+              className={`text-[10px] font-bold ${isAutoPlay ? '' : dk ? 'text-slate-600' : 'text-slate-400'}`}
+              style={isAutoPlay ? { color: accentRgba(rgb, dk ? 0.95 : 0.88) } : undefined}
+            >
               {isAutoPlay ? '切換え中' : '自動切換え'}
             </span>
           </div>

--- a/Frontend/src/app/components/DictionaryManagerModal.tsx
+++ b/Frontend/src/app/components/DictionaryManagerModal.tsx
@@ -9,6 +9,8 @@ import {
   type DictionaryEntry,
   updateDictionaryEntry,
 } from '@/app/utils/dictionaryApi';
+import { useAccentTheme } from '../../theme/AccentThemeContext';
+import { accentRgba, micStartButtonStyle } from '../../theme/accentStyles';
 
 interface DictionaryManagerModalProps {
   isOpen: boolean;
@@ -34,6 +36,7 @@ export const DictionaryManagerModal: React.FC<DictionaryManagerModalProps> = ({
   darkMode = true,
 }) => {
   const dk = darkMode;
+  const { rgb } = useAccentTheme();
   const [entries, setEntries] = useState<DictionaryEntry[]>([]);
   const [total, setTotal] = useState(0);
   const [query, setQuery] = useState('');
@@ -168,7 +171,7 @@ export const DictionaryManagerModal: React.FC<DictionaryManagerModalProps> = ({
         <div className={`px-5 py-4 border-b ${dk ? 'border-slate-800/70' : 'border-slate-200'}`}>
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-2">
-              <BookOpenText size={16} className="text-indigo-400" />
+              <BookOpenText size={16} style={{ color: accentRgba(rgb, dk ? 0.85 : 0.72) }} />
               <h2 className="text-sm sm:text-base font-black">単語管理</h2>
               <span className={`text-[11px] font-mono ${dk ? 'text-slate-500' : 'text-slate-500'}`}>
                 total: {total}
@@ -207,11 +210,8 @@ export const DictionaryManagerModal: React.FC<DictionaryManagerModalProps> = ({
               <button
                 onClick={handleBulkRegister}
                 disabled={registering}
-                className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-colors flex items-center gap-1.5 ${
-                  dk
-                    ? 'bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50'
-                    : 'bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50'
-                }`}
+                className="px-3 py-1.5 rounded-lg text-xs font-bold transition-[filter] flex items-center gap-1.5 text-white hover:brightness-110 disabled:opacity-50"
+                style={micStartButtonStyle(rgb, dk)}
               >
                 {registering ? <Loader2 size={13} className="animate-spin" /> : null}
                 登録実行
@@ -377,7 +377,8 @@ export const DictionaryManagerModal: React.FC<DictionaryManagerModalProps> = ({
               <button
                 onClick={() => void saveEdit()}
                 disabled={savingEdit}
-                className="px-3 py-1.5 rounded-lg text-xs font-bold bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 flex items-center gap-1.5"
+                className="px-3 py-1.5 rounded-lg text-xs font-bold text-white flex items-center gap-1.5 transition-[filter] hover:brightness-110 disabled:opacity-50"
+                style={micStartButtonStyle(rgb, dk)}
               >
                 {savingEdit ? <Loader2 size={12} className="animate-spin" /> : null}
                 保存

--- a/Frontend/src/app/components/HistoryPanel.tsx
+++ b/Frontend/src/app/components/HistoryPanel.tsx
@@ -3,6 +3,8 @@ import { Term } from '../data/terms';
 import { History, Trash2, ChevronRight, Search } from 'lucide-react';
 import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
 import { scaledContentFontPx } from '../utils/contentFontScale';
+import { useAccentTheme } from '../../theme/AccentThemeContext';
+import { accentRgba } from '../../theme/accentStyles';
 
 const CATEGORY_DOT: Record<string, string> = {
   Frontend: '#60a5fa',
@@ -23,6 +25,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({ history, onTermClick
   const [search, setSearch] = useState('');
   const dk = darkMode;
   const contentFontScale = useContentFontScaleStore(s => s.scale);
+  const { rgb } = useAccentTheme();
 
   const filtered = history.filter(t =>
     t.word.toLowerCase().includes(search.toLowerCase()) ||
@@ -35,7 +38,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({ history, onTermClick
       <div className={`p-4 border-b flex-shrink-0 ${dk ? 'border-slate-800/60' : 'border-slate-100'}`}>
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <History size={14} className="text-indigo-400" />
+            <History size={14} style={{ color: accentRgba(rgb, dk ? 0.85 : 0.72) }} />
             <span className="text-sm font-black">検索履歴</span>
           </div>
           {history.length > 0 && (
@@ -71,7 +74,16 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({ history, onTermClick
               <button
                 key={`${t.id}-${i}`}
                 onClick={() => onTermClick(t)}
-                className={`w-full flex items-center gap-3 p-2.5 rounded-xl text-left transition-all border ${dk ? 'border-transparent hover:bg-slate-800/60 hover:border-indigo-500/20' : 'border-transparent hover:bg-slate-50 hover:border-indigo-200'}`}
+                className={`w-full flex items-center gap-3 p-2.5 rounded-xl text-left transition-all border-l-2 ${
+                  dk ? 'hover:bg-slate-800/60' : 'hover:bg-slate-50'
+                }`}
+                style={{ borderLeftColor: 'transparent' }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.borderLeftColor = accentRgba(rgb, dk ? 0.55 : 0.4);
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.borderLeftColor = 'transparent';
+                }}
               >
                 <span
                   className="w-2 h-2 rounded-full flex-shrink-0"

--- a/Frontend/src/app/components/SettingsModal.tsx
+++ b/Frontend/src/app/components/SettingsModal.tsx
@@ -8,6 +8,8 @@ import {
   CONTENT_FONT_SCALE_MIN,
   useContentFontScaleStore,
 } from '../../stores/contentFontScaleStore';
+import { useAccentTheme } from '../../theme/AccentThemeContext';
+import { accentRgba, accentRgbSolid, accentSliderStyle } from '../../theme/accentStyles';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -53,28 +55,35 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   const { mode, setMode, microphones, selectedMicrophoneId, selectMicrophone, refreshMicrophones } = useTranscription();
   const contentFontScale = useContentFontScaleStore(s => s.scale);
   const setContentFontScale = useContentFontScaleStore(s => s.setScale);
+  const { rgb } = useAccentTheme();
 
   if (!isOpen) return null;
 
   const dk = settings.darkMode;
 
-  const modeBtn = (val: TranscriptionMode, label: string) => (
-    <button
-      key={val}
-      onClick={() => setMode(val)}
-      className={`flex-1 rounded-lg border py-1.5 text-xs font-bold transition-colors ${
-        mode === val
-          ? dk
-            ? 'border-indigo-500 bg-indigo-500/15 text-indigo-300'
-            : 'border-indigo-500 bg-indigo-50 text-indigo-700'
-          : dk
-            ? 'border-slate-700 text-slate-400 hover:bg-slate-800'
-            : 'border-slate-200 text-slate-500 hover:bg-slate-50'
-      }`}
-    >
-      {label}
-    </button>
-  );
+  const modeBtn = (val: TranscriptionMode, label: string) => {
+    const active = mode === val;
+    return (
+      <button
+        key={val}
+        onClick={() => setMode(val)}
+        className={`flex-1 rounded-lg border py-1.5 text-xs font-bold transition-colors ${
+          active ? '' : dk ? 'border-slate-700 text-slate-400 hover:bg-slate-800' : 'border-slate-200 text-slate-500 hover:bg-slate-50'
+        }`}
+        style={
+          active
+            ? {
+                borderColor: accentRgba(rgb, dk ? 0.65 : 0.5),
+                backgroundColor: accentRgba(rgb, dk ? 0.2 : 0.1),
+                color: accentRgba(rgb, dk ? 0.96 : 0.88),
+              }
+            : undefined
+        }
+      >
+        {label}
+      </button>
+    );
+  };
 
   return (
     <AnimatePresence>
@@ -97,7 +106,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
           <div className="p-4">
             <div className="flex justify-between items-center mb-4">
               <div className="flex items-center gap-2">
-                <Settings size={16} className="text-indigo-400" />
+                <Settings size={16} style={{ color: accentRgba(rgb, dk ? 0.88 : 0.75) }} />
                 <h2 className="text-base font-black">設定</h2>
               </div>
               <button onClick={onClose} className={`p-1.5 rounded-lg transition-colors ${dk ? 'hover:bg-slate-800 text-slate-500' : 'hover:bg-slate-100 text-slate-400'}`}>
@@ -117,10 +126,11 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                   <span className="text-xs font-bold">ダークモード</span>
                   <button
                     onClick={() => updateSettings({ darkMode: !settings.darkMode })}
-                    className={`w-10 h-5 rounded-full relative transition-colors ${settings.darkMode ? 'bg-indigo-600' : 'bg-slate-200'}`}
+                    className={`w-10 h-5 rounded-full relative transition-colors ${settings.darkMode ? '' : 'bg-slate-200'}`}
+                    style={settings.darkMode ? { backgroundColor: accentRgbSolid(rgb) } : undefined}
                   >
                     <div className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-all ${settings.darkMode ? 'left-[22px]' : 'left-0.5'} flex items-center justify-center shadow-sm`}>
-                      {settings.darkMode ? <Moon size={8} className="text-indigo-600" /> : <Sun size={8} className="text-amber-500" />}
+                      {settings.darkMode ? <Moon size={8} style={{ color: accentRgbSolid(rgb) }} /> : <Sun size={8} className="text-amber-500" />}
                     </div>
                   </button>
                 </div>
@@ -132,7 +142,14 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                       <button
                         key={color.value}
                         onClick={() => updateSettings({ themeColor: color.value })}
-                        className={`w-7 h-7 rounded-full transition-all ${color.bg} ${settings.themeColor === color.value ? `ring-2 ring-offset-2 ${dk ? 'ring-offset-[#12132a]' : 'ring-offset-white'} ring-slate-400 scale-110` : 'opacity-60 hover:opacity-100'}`}
+                        className={`w-7 h-7 rounded-full transition-all ${color.bg} ${
+                          settings.themeColor === color.value ? 'scale-110' : 'opacity-60 hover:opacity-100'
+                        }`}
+                        style={
+                          settings.themeColor === color.value
+                            ? { boxShadow: `0 0 0 2px ${dk ? '#0f172a' : '#fff'}, 0 0 0 4px ${accentRgbSolid(rgb)}, 0 0 18px ${accentRgba(rgb, 0.5)}` }
+                            : undefined
+                        }
                         title={color.name}
                       />
                     ))}
@@ -157,7 +174,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                   step={5}
                   value={Math.round(contentFontScale * 100)}
                   onChange={(e) => setContentFontScale(Number(e.target.value) / 100)}
-                  className={`mb-1.5 w-full cursor-pointer accent-indigo-500 ${dk ? 'opacity-95' : ''}`}
+                  className={`mb-1.5 w-full cursor-pointer ${dk ? 'opacity-95' : ''}`}
+                  style={accentSliderStyle(rgb)}
                   aria-valuemin={Math.round(CONTENT_FONT_SCALE_MIN * 100)}
                   aria-valuemax={Math.round(CONTENT_FONT_SCALE_MAX * 100)}
                   aria-valuenow={Math.round(contentFontScale * 100)}
@@ -234,7 +252,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                     </div>
                     <button
                       onClick={() => onSimilarityFilterEnabledChange(!similarityFilterEnabled)}
-                      className={`w-10 h-5 rounded-full relative transition-colors ${similarityFilterEnabled ? 'bg-indigo-600' : (dk ? 'bg-slate-700' : 'bg-slate-200')}`}
+                      className={`w-10 h-5 rounded-full relative transition-colors ${similarityFilterEnabled ? '' : (dk ? 'bg-slate-700' : 'bg-slate-200')}`}
+                      style={similarityFilterEnabled ? { backgroundColor: accentRgbSolid(rgb) } : undefined}
                     >
                       <div className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-all shadow-sm ${similarityFilterEnabled ? 'left-[22px]' : 'left-0.5'}`} />
                     </button>
@@ -253,7 +272,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                         step={1}
                         value={similarityFilterStrength}
                         onChange={(e) => onSimilarityFilterStrengthChange(Number(e.target.value))}
-                        className="w-full h-1 rounded-lg appearance-none cursor-pointer bg-slate-700 accent-indigo-500"
+                        className="w-full h-1 rounded-lg appearance-none cursor-pointer bg-slate-700"
+                        style={accentSliderStyle(rgb)}
                       />
                       <div className={`flex justify-between mt-0.5 text-[9px] ${dk ? 'text-slate-600' : 'text-slate-400'}`}>
                         <span>広く</span>

--- a/Frontend/src/app/components/TermBubble.tsx
+++ b/Frontend/src/app/components/TermBubble.tsx
@@ -5,6 +5,8 @@ import { Term } from '../data/terms';
 import { Info, Star } from 'lucide-react';
 import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
 import { scaledContentFontPx } from '../utils/contentFontScale';
+import { useAccentTheme } from '../../theme/AccentThemeContext';
+import { accentRgba } from '../../theme/accentStyles';
 
 const TOOLTIP = { W: 176, H: 120, PAD: 8, GAP_ABOVE: 12 } as const;
 
@@ -37,6 +39,7 @@ export const TermBubble: React.FC<TermBubbleProps> = ({
   mapContainerRef,
 }) => {
   const contentFontScale = useContentFontScaleStore(s => s.scale);
+  const { rgb } = useAccentTheme();
   const [isHovered, setIsHovered] = useState(false);
   const [isShowingDesc, setIsShowingDesc] = useState(false);
   const [tooltipPos, setTooltipPos] = useState<{ left: number; top: number; showBelow: boolean } | null>(null);
@@ -283,8 +286,8 @@ export const TermBubble: React.FC<TermBubbleProps> = ({
         >
             <div className="flex items-center gap-1.5 mb-1">
               <span
-                className={`font-bold ${dk ? 'text-indigo-400' : 'text-indigo-500'}`}
-                style={{ fontSize: scaledContentFontPx(9, contentFontScale) }}
+                className="font-bold"
+                style={{ fontSize: scaledContentFontPx(9, contentFontScale), color: accentRgba(rgb, dk ? 0.92 : 0.88) }}
               >
                 {term.category}
               </span>
@@ -313,8 +316,8 @@ export const TermBubble: React.FC<TermBubbleProps> = ({
               {term.shortDesc}
             </p>
             <div
-              className={`mt-1.5 font-medium flex items-center gap-1 ${dk ? 'text-indigo-400' : 'text-indigo-500'}`}
-              style={{ fontSize: scaledContentFontPx(9, contentFontScale) }}
+              className="mt-1.5 font-medium flex items-center gap-1"
+              style={{ fontSize: scaledContentFontPx(9, contentFontScale), color: accentRgba(rgb, dk ? 0.88 : 0.82) }}
             >
               <Info size={8} /> クリックで詳細
             </div>

--- a/Frontend/src/app/components/TermDetailPanel.tsx
+++ b/Frontend/src/app/components/TermDetailPanel.tsx
@@ -3,6 +3,8 @@ import { Term } from '../data/terms';
 import { X, ExternalLink, Hash, BookOpen, Layers, Star, Copy } from 'lucide-react';
 import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
 import { scaledContentFontPx } from '../utils/contentFontScale';
+import { useAccentTheme } from '../../theme/AccentThemeContext';
+import { accentRgba, micStartButtonStyle } from '../../theme/accentStyles';
 
 interface TermDetailPanelProps {
   term: Term | null;
@@ -23,6 +25,7 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
 }) => {
   const dk = darkMode;
   const contentFontScale = useContentFontScaleStore(s => s.scale);
+  const { rgb } = useAccentTheme();
 
   if (!term) {
     return (
@@ -131,14 +134,15 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
       {/* Body */}
       <div className="flex-1 overflow-y-auto p-5 space-y-5">
         <section>
-          <div className={`flex items-center justify-between gap-2 mb-2 text-xs font-bold ${dk ? 'text-indigo-400' : 'text-indigo-600'}`}>
+          <div className="flex items-center justify-between gap-2 mb-2 text-xs font-bold" style={{ color: accentRgba(rgb, dk ? 0.9 : 0.82) }}>
             <span className="flex items-center gap-1.5">
               <BookOpen size={13} /><span>説明</span>
             </span>
             <button
               onClick={copyDesc}
               title="説明をコピー"
-              className={`p-1.5 rounded-lg transition-colors shrink-0 ${dk ? 'hover:bg-slate-800 text-indigo-400/80 hover:text-indigo-400' : 'hover:bg-slate-100 text-indigo-600/80 hover:text-indigo-600'}`}
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${dk ? 'hover:bg-slate-800' : 'hover:bg-slate-100'}`}
+              style={{ color: accentRgba(rgb, dk ? 0.85 : 0.75) }}
             >
               <Copy size={13} />
             </button>
@@ -154,7 +158,7 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
 
         {related.length > 0 && (
           <section className="hidden">
-            <div className={`flex items-center gap-1.5 mb-2 text-xs font-bold ${dk ? 'text-indigo-400' : 'text-indigo-600'}`}>
+            <div className="flex items-center gap-1.5 mb-2 text-xs font-bold" style={{ color: accentRgba(rgb, dk ? 0.9 : 0.82) }}>
               <Layers size={13} /><span>関連ワード</span>
             </div>
             <div className="flex flex-wrap gap-1.5">
@@ -162,7 +166,12 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
                 <button
                   key={r.id}
                   onClick={() => onRelatedTermClick(r)}
-                  className={`px-2.5 py-1 rounded-lg text-xs font-bold border transition-all flex items-center gap-1 ${dk ? 'border-indigo-500/20 bg-indigo-500/10 text-indigo-300 hover:bg-indigo-500/20' : 'border-indigo-200 bg-indigo-50 text-indigo-700 hover:bg-indigo-100'}`}
+                  className={`px-2.5 py-1 rounded-lg text-xs font-bold border transition-all flex items-center gap-1 ${dk ? 'hover:brightness-110' : 'hover:brightness-95'}`}
+                  style={{
+                    borderColor: accentRgba(rgb, dk ? 0.35 : 0.28),
+                    backgroundColor: accentRgba(rgb, dk ? 0.14 : 0.08),
+                    color: accentRgba(rgb, dk ? 0.95 : 0.88),
+                  }}
                 >
                   <Hash size={9} />{r.word}
                 </button>
@@ -192,7 +201,8 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
             href={term.externalUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex-1 flex items-center justify-center gap-1.5 py-2 rounded-xl text-xs font-bold bg-indigo-600 text-white hover:bg-indigo-500 transition-colors"
+            className="flex-1 flex items-center justify-center gap-1.5 py-2 rounded-xl text-xs font-bold transition-[filter] hover:brightness-110 text-white"
+            style={micStartButtonStyle(rgb, dk)}
           >
             公式サイト<ExternalLink size={11} />
           </a>

--- a/Frontend/src/app/components/TranscriptionView.tsx
+++ b/Frontend/src/app/components/TranscriptionView.tsx
@@ -9,6 +9,8 @@ import type { MicrophoneDevice, TranscriptionMode } from '../../domain/interface
 import { RecordingToolbar } from '../../presentation/components/RecordingToolbar';
 import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
 import { scaledContentFontPx } from '../utils/contentFontScale';
+import { useAccentTheme } from '../../theme/AccentThemeContext';
+import { accentRgba, accentRgbSolid, accentSliderStyle, termChipStyle } from '../../theme/accentStyles';
 
 const TOOLTIP = { W: 208, H: 100, PAD: 8, GAP_ABOVE: 12 } as const;
 
@@ -67,6 +69,7 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
   const scrollRef = useRef<HTMLDivElement>(null);
   const termButtonRefs = useRef<Record<number, HTMLButtonElement | null>>({});
   const contentFontScale = useContentFontScaleStore(s => s.scale);
+  const { rgb } = useAccentTheme();
   const [hoveredPartIndex, setHoveredPartIndex] = useState<number | null>(null);
   const [tooltipPos, setTooltipPos] = useState<{ left: number; top: number; showBelow: boolean } | null>(null);
 
@@ -170,10 +173,28 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
       >
         {!transcript ? (
           <div className={`h-full flex flex-col items-center justify-center text-center gap-3 ${dk ? 'text-slate-600' : 'text-slate-300'}`}>
-            <div className={`w-16 h-16 rounded-full flex items-center justify-center border-2 ${
-              isListening ? (dk ? 'border-indigo-500/50 bg-indigo-500/10' : 'border-indigo-300 bg-indigo-50') : (dk ? 'border-slate-700 bg-slate-800/50' : 'border-slate-200 bg-slate-50')
-            }`}>
-              <Radio size={28} className={isListening ? (dk ? 'text-indigo-400' : 'text-indigo-500') : (dk ? 'text-slate-600' : 'text-slate-300')} />
+            <div
+              className={`w-16 h-16 rounded-full flex items-center justify-center border-2 ${
+                isListening ? '' : (dk ? 'border-slate-700 bg-slate-800/50' : 'border-slate-200 bg-slate-50')
+              }`}
+              style={
+                isListening
+                  ? {
+                      borderColor: accentRgba(rgb, dk ? 0.55 : 0.45),
+                      backgroundColor: accentRgba(rgb, dk ? 0.12 : 0.08),
+                    }
+                  : undefined
+              }
+            >
+              <Radio
+                size={28}
+                style={
+                  isListening
+                    ? { color: accentRgbSolid(rgb) }
+                    : undefined
+                }
+                className={isListening ? '' : (dk ? 'text-slate-600' : 'text-slate-300')}
+              />
             </div>
             <div>
               <p className={`text-sm font-bold ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
@@ -227,11 +248,8 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
                       }}
                       onMouseEnter={() => { setHoveredPartIndex(index); onTermHover(term); }}
                       onMouseLeave={() => { setHoveredPartIndex(null); onTermHover(null); }}
-                      className={`px-1.5 py-0.5 rounded-md cursor-pointer transition-all font-bold ${
-                        dk
-                          ? 'bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/35 border border-indigo-500/30'
-                          : 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200'
-                      }`}
+                      className="px-1.5 py-0.5 rounded-md cursor-pointer transition-[filter,transform] font-bold hover:brightness-110"
+                      style={termChipStyle(dk, rgb)}
                     >
                       {part.content}
                     </button>
@@ -242,7 +260,13 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
               return <span key={index}>{part.content}</span>;
             })}
             {isListening && (
-              <span className={`inline-block w-0.5 h-4 ml-0.5 ${dk ? 'bg-indigo-400 shadow-lg shadow-indigo-400/50' : 'bg-indigo-500'} animate-pulse align-middle rounded-full`} />
+              <span
+                className="inline-block w-0.5 h-4 ml-0.5 animate-pulse align-middle rounded-full"
+                style={{
+                  backgroundColor: accentRgbSolid(rgb),
+                  boxShadow: dk ? `0 0 12px ${accentRgba(rgb, 0.55)}` : `0 0 8px ${accentRgba(rgb, 0.35)}`,
+                }}
+              />
             )}
             {isStreaming && (
               <span className={`inline-block w-0.5 h-4 ml-0.5 bg-purple-400 animate-pulse align-middle rounded-full`} />
@@ -271,8 +295,11 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
             )}
             <div className="flex items-center gap-2 mb-1.5">
               <span
-                className={`font-bold ${dk ? 'text-indigo-400' : 'text-indigo-300'}`}
-                style={{ fontSize: scaledContentFontPx(10, contentFontScale) }}
+                className="font-bold"
+                style={{
+                  fontSize: scaledContentFontPx(10, contentFontScale),
+                  color: accentRgba(rgb, dk ? 0.92 : 0.85),
+                }}
               >
                 {hoveredTerm.category}
               </span>
@@ -374,9 +401,12 @@ export const TranscriptionView: React.FC<TranscriptionViewProps> = ({
                       value={pos}
                       onChange={e => demoStream.setIntervalMs(posToMs(Number(e.target.value)))}
                       className={`w-full h-1.5 rounded-full appearance-none cursor-pointer ${
-                        isStreaming ? 'accent-purple-500' : (dk ? 'accent-slate-500' : 'accent-slate-400')
+                        isStreaming ? 'accent-purple-500' : ''
                       }`}
-                      style={{ background: dk ? '#1e293b' : '#e2e8f0' }}
+                      style={{
+                        background: dk ? '#1e293b' : '#e2e8f0',
+                        ...(isStreaming ? {} : accentSliderStyle(rgb)),
+                      }}
                       title={`速度: ${demoStream.intervalMs}ms (${pos}/100)`}
                     />
                     <div className={`flex justify-between text-[8px] font-bold ${dk ? 'text-slate-700' : 'text-slate-300'}`}>

--- a/Frontend/src/app/layout/LayoutEngine.tsx
+++ b/Frontend/src/app/layout/LayoutEngine.tsx
@@ -177,8 +177,19 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({ layout, onLayoutChan
                     </div>
 
                     {/* パネルコンテンツ */}
-                    <div style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}>
-                        {panels[node.panelId]}
+                    <div style={{ flex: 1, minHeight: 0, position: 'relative', overflow: 'hidden' }}>
+                        <div className="relative z-0 h-full min-h-0 overflow-hidden">
+                            {panels[node.panelId]}
+                        </div>
+                        <div
+                            aria-hidden
+                            className="pointer-events-none absolute inset-0 z-[1]"
+                            style={{
+                                background: dk
+                                    ? `radial-gradient(115% 90% at 50% -5%, rgba(${accentRgb},0.13) 0%, rgba(${accentRgb},0.045) 38%, transparent 68%)`
+                                    : `radial-gradient(110% 85% at 50% -5%, rgba(${accentRgb},0.1) 0%, rgba(${accentRgb},0.035) 42%, transparent 70%)`,
+                            }}
+                        />
                     </div>
 
                     {/* ドラッグ中: ドロップゾーンオーバーレイ */}

--- a/Frontend/src/app/layout/LayoutEngine.tsx
+++ b/Frontend/src/app/layout/LayoutEngine.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { GripHorizontal, X } from 'lucide-react';
 import { DropZone, LayoutNode, PanelId } from './types';
 import { movePanel, updateRatio } from './layoutUtils';
+import { getAccentRgb } from '../../theme/accentTokens';
 
 // ── パネルラベル ────────────────────────────────────
 const PANEL_LABELS: Record<PanelId, string> = {
@@ -9,16 +10,6 @@ const PANEL_LABELS: Record<PanelId, string> = {
     bubbleCloud: '用語マップ',
     detail: '詳細',
     history: '履歴',
-};
-
-// ── アクセントカラー→RGB値マッピング ────────────────
-const ACCENT_RGB: Record<string, string> = {
-    blue: '59,130,246',
-    indigo: '99,102,241',
-    purple: '168,85,247',
-    rose: '244,63,94',
-    emerald: '16,185,129',
-    orange: '249,115,22',
 };
 
 // ── ドロップゾーンオーバーレイ ──────────────────────
@@ -97,10 +88,13 @@ export interface LayoutEngineProps {
 
 export const LayoutEngine: React.FC<LayoutEngineProps> = ({ layout, onLayoutChange, darkMode, themeColor = 'indigo', panels, onClose }) => {
     const dk = darkMode;
-    const accentRgb = ACCENT_RGB[themeColor] ?? ACCENT_RGB['indigo'];
-    const borderStyle = `2px solid rgba(${accentRgb},0.6)`;
-    const headerBg = `rgba(${accentRgb},0.07)`;
+    const accentRgb = getAccentRgb(themeColor);
+    const borderStyle = `2px solid rgba(${accentRgb},0.72)`;
+    const headerBg = `rgba(${accentRgb},${dk ? 0.18 : 0.12})`;
     const dotColor = `rgba(${accentRgb},1)`;
+    const panelGlow = dk
+        ? `0 0 0 1px rgba(${accentRgb},0.14), 0 12px 40px rgba(${accentRgb},0.1)`
+        : `0 0 0 1px rgba(${accentRgb},0.18), 0 10px 36px rgba(${accentRgb},0.08)`;
 
     const [dragging, setDragging] = useState<PanelId | null>(null);
     const [dropInfo, setDropInfo] = useState<{ panelId: PanelId; zone: DropZone } | null>(null);
@@ -147,6 +141,7 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({ layout, onLayoutChan
                         overflow: 'hidden',
                         border: borderStyle,
                         borderRadius: 6,
+                        boxShadow: panelGlow,
                     }}
                 >
                     {/* コンパクトドラッグハンドルヘッダー */}
@@ -154,10 +149,10 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({ layout, onLayoutChan
                         draggable
                         onDragStart={e => { e.dataTransfer.effectAllowed = 'move'; setDragging(node.panelId); }}
                         onDragEnd={() => { setDragging(null); setDropInfo(null); }}
-                        className={`flex items-center gap-1.5 px-2.5 py-1 flex-shrink-0 cursor-grab active:cursor-grabbing select-none border-b ${dk ? 'text-slate-400 hover:text-slate-200' : 'text-slate-500 hover:text-slate-700'}`}
+                        className={`flex items-center gap-1.5 px-2.5 py-1 flex-shrink-0 cursor-grab active:cursor-grabbing select-none border-b font-semibold ${dk ? 'text-slate-300 hover:text-white' : 'text-slate-600 hover:text-slate-900'}`}
                         style={{
                             backgroundColor: headerBg,
-                            borderBottomColor: `rgba(${accentRgb},0.3)`,
+                            borderBottomColor: `rgba(${accentRgb},0.42)`,
                         }}
                     >
                         {/* アクセントカラードット */}
@@ -237,7 +232,7 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({ layout, onLayoutChan
             </div>
         );
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [dragging, dropInfo, dk, panels, accentRgb, borderStyle, headerBg, dotColor, calcZone, onLayoutChange, onClose]);
+    }, [dragging, dropInfo, dk, panels, accentRgb, borderStyle, headerBg, dotColor, panelGlow, calcZone, onLayoutChange, onClose]);
 
     return (
         <div style={{ width: '100%', height: '100%', overflow: 'hidden' }}>

--- a/Frontend/src/presentation/App.tsx
+++ b/Frontend/src/presentation/App.tsx
@@ -15,6 +15,7 @@ import { useTranscriptStore } from '../stores/transcriptStore'
 import { useTermStore } from '../stores/termStore'
 import { useBubbleStore } from '../stores/bubbleStore'
 import { getOppositeThemeColor } from './utils/oppositeThemeColor'
+import { AccentThemeProvider } from '../theme/AccentThemeContext'
 
 // ウィンドウを一度だけ登録
 let _registered = false
@@ -68,6 +69,7 @@ const App: React.FC = () => {
         }}
       >
         <DemoImportantTermsBridge />
+        <AccentThemeProvider themeColor={phaseAccentColor}>
         <div
           className={`w-screen h-screen flex flex-col overflow-hidden ${dk ? 'bg-[#0a0b14] text-slate-100' : 'bg-slate-50 text-slate-900'}`}
         >
@@ -94,6 +96,7 @@ const App: React.FC = () => {
 
           <Toaster position="bottom-right" theme={darkMode ? 'dark' : 'light'} />
         </div>
+        </AccentThemeProvider>
       </PresentationShellProvider>
     </DemoToolsProvider>
   )

--- a/Frontend/src/presentation/components/LayoutPresetMenu.tsx
+++ b/Frontend/src/presentation/components/LayoutPresetMenu.tsx
@@ -14,6 +14,7 @@ import {
   removeUserWindowFromDockedLayout,
 } from '../layout/layoutUtils'
 import { getLayoutSelectableWindows } from '../windows/registry'
+import { useAccentTheme } from '../../theme/AccentThemeContext'
 
 const PRESETS = [
   { key: 'default', label: 'デフォルト', make: makeDefaultLayout },
@@ -37,7 +38,7 @@ interface Props {
 }
 
 const focusRing =
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:ring-offset-2'
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--app-accent-rgb)/0.45)] focus-visible:ring-offset-2'
 
 export const LayoutPresetMenu: React.FC<Props> = ({
   darkMode = true,
@@ -49,6 +50,7 @@ export const LayoutPresetMenu: React.FC<Props> = ({
 }) => {
   const rootRef = useRef<HTMLDivElement>(null)
   const [open, setOpen] = useState(false)
+  const { rgb } = useAccentTheme()
   const setLayout = useLayoutStore(s => s.setLayout)
   const layout = useLayoutStore(s => s.layouts[phaseId])
   const menuPos = menuAlign === 'right' ? 'right-0 left-auto' : 'left-0'
@@ -107,7 +109,7 @@ export const LayoutPresetMenu: React.FC<Props> = ({
 
   const dk = darkMode
   const rowHover = dk ? 'hover:bg-slate-800/80' : 'hover:bg-slate-50'
-  const chk = dk ? 'accent-indigo-500 border-slate-600' : 'accent-indigo-600 border-slate-300'
+  const chk = dk ? 'border-slate-600' : 'border-slate-300'
 
   return (
     <div
@@ -158,6 +160,7 @@ export const LayoutPresetMenu: React.FC<Props> = ({
                 <input
                   type="checkbox"
                   className={`size-4 shrink-0 rounded border ${chk}`}
+                  style={{ accentColor: `rgb(${rgb})` }}
                   checked={activeIds.has(def.id)}
                   onChange={e => {
                     e.stopPropagation()

--- a/Frontend/src/presentation/components/PresentationAppHeader.tsx
+++ b/Frontend/src/presentation/components/PresentationAppHeader.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Settings } from 'lucide-react'
 import { LayoutPresetMenu } from './LayoutPresetMenu'
 import { TestFeaturesPopover } from './TestFeaturesPopover'
+import { useAccentTheme } from '../../theme/AccentThemeContext'
+import { accentRgba } from '../../theme/accentStyles'
 
 export interface PresentationAppHeaderProps {
   darkMode: boolean
@@ -10,7 +12,7 @@ export interface PresentationAppHeaderProps {
 }
 
 const focusRing =
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:ring-offset-2'
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--app-accent-rgb)/0.45)] focus-visible:ring-offset-2'
 
 /**
  * プレゼンレイヤのヘッダー（ブランド・フェーズ・レイアウト・設定・開発テスト）。
@@ -21,6 +23,7 @@ export const PresentationAppHeader: React.FC<PresentationAppHeaderProps> = ({
   onOpenAppearance,
 }) => {
   const dk = darkMode
+  const { rgb } = useAccentTheme()
   const isDuring = currentPhaseId === 'during'
   const ringOffset = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
   const settingsPill = dk
@@ -39,17 +42,25 @@ export const PresentationAppHeader: React.FC<PresentationAppHeaderProps> = ({
         >
           TALKSCOPE
         </span>
-        <span
-          className={`shrink-0 text-xs font-bold px-2.5 py-1 rounded-full ${isDuring
-            ? dk
-              ? 'bg-emerald-500/20 text-emerald-400'
-              : 'bg-emerald-100 text-emerald-700'
-            : dk
-              ? 'bg-violet-500/20 text-violet-400'
-              : 'bg-violet-100 text-violet-700'}`}
-        >
-          {isDuring ? '発表中' : '発表後'}
-        </span>
+        {isDuring ? (
+          <span
+            className={`shrink-0 text-xs font-bold px-2.5 py-1 rounded-full ${
+              dk ? 'bg-emerald-500/20 text-emerald-400' : 'bg-emerald-100 text-emerald-700'
+            }`}
+          >
+            発表中
+          </span>
+        ) : (
+          <span
+            className="shrink-0 text-xs font-bold px-2.5 py-1 rounded-full"
+            style={{
+              backgroundColor: accentRgba(rgb, dk ? 0.22 : 0.12),
+              color: accentRgba(rgb, dk ? 0.94 : 0.88),
+            }}
+          >
+            発表後
+          </span>
+        )}
       </div>
 
       <div className="flex shrink-0 flex-wrap items-center justify-end gap-2" aria-label="ツールバー">

--- a/Frontend/src/presentation/components/RecordingToolbar.tsx
+++ b/Frontend/src/presentation/components/RecordingToolbar.tsx
@@ -2,9 +2,6 @@ import React from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { Mic, Square } from 'lucide-react'
 import type { MicrophoneDevice, TranscriptionMode } from '../../domain/interfaces/ITranscriptionService'
-import { useAccentTheme } from '../../theme/AccentThemeContext'
-import { micStartButtonStyle } from '../../theme/accentStyles'
-
 export type RecordingToolbarProps = {
   darkMode?: boolean
   isListening: boolean
@@ -35,7 +32,6 @@ export const RecordingToolbar: React.FC<RecordingToolbarProps> = ({
   variant = 'full',
 }) => {
   const dk = darkMode
-  const { rgb } = useAccentTheme()
   const btnSize = compact ? 'w-14 h-14' : 'w-20 h-20'
   const iconMic = compact ? 24 : 32
   const iconSq = compact ? 20 : 26
@@ -56,10 +52,10 @@ export const RecordingToolbar: React.FC<RecordingToolbarProps> = ({
                 exit={{ scale: 0.8, opacity: 0 }}
                 transition={{ type: 'spring', stiffness: 300, damping: 22 }}
                 whileTap={{ scale: 0.92 }}
-                className={`${btnSize} rounded-full flex items-center justify-center relative shadow-2xl bg-red-500 hover:bg-red-400 text-white shadow-red-500/30`}
+                className={`${btnSize} rounded-full flex items-center justify-center relative shadow-2xl bg-emerald-500 hover:bg-emerald-400 text-white shadow-emerald-500/30`}
                 title="録音を中断"
               >
-                <span className="absolute inset-0 rounded-full bg-red-400 animate-ping opacity-25 pointer-events-none" />
+                <span className="absolute inset-0 rounded-full bg-emerald-400 animate-ping opacity-25 pointer-events-none" />
                 <Square size={iconSq} fill="currentColor" />
               </motion.button>
             ) : (
@@ -71,8 +67,7 @@ export const RecordingToolbar: React.FC<RecordingToolbarProps> = ({
                 exit={{ scale: 0.8, opacity: 0 }}
                 transition={{ type: 'spring', stiffness: 300, damping: 22 }}
                 whileTap={{ scale: 0.92 }}
-                className={`${btnSize} rounded-full flex items-center justify-center shadow-2xl transition-[filter] hover:brightness-110`}
-                style={micStartButtonStyle(rgb, dk)}
+                className={`${btnSize} rounded-full flex items-center justify-center shadow-2xl bg-violet-600 hover:bg-violet-500 text-white shadow-violet-500/35`}
                 title="録音開始"
               >
                 <Mic size={iconMic} />

--- a/Frontend/src/presentation/components/RecordingToolbar.tsx
+++ b/Frontend/src/presentation/components/RecordingToolbar.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { Mic, Square } from 'lucide-react'
 import type { MicrophoneDevice, TranscriptionMode } from '../../domain/interfaces/ITranscriptionService'
+import { useAccentTheme } from '../../theme/AccentThemeContext'
+import { micStartButtonStyle } from '../../theme/accentStyles'
 
 export type RecordingToolbarProps = {
   darkMode?: boolean
@@ -33,6 +35,7 @@ export const RecordingToolbar: React.FC<RecordingToolbarProps> = ({
   variant = 'full',
 }) => {
   const dk = darkMode
+  const { rgb } = useAccentTheme()
   const btnSize = compact ? 'w-14 h-14' : 'w-20 h-20'
   const iconMic = compact ? 24 : 32
   const iconSq = compact ? 20 : 26
@@ -68,11 +71,8 @@ export const RecordingToolbar: React.FC<RecordingToolbarProps> = ({
                 exit={{ scale: 0.8, opacity: 0 }}
                 transition={{ type: 'spring', stiffness: 300, damping: 22 }}
                 whileTap={{ scale: 0.92 }}
-                className={`${btnSize} rounded-full flex items-center justify-center shadow-2xl ${
-                  dk
-                    ? 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/40'
-                    : 'bg-indigo-600 hover:bg-indigo-500 text-white shadow-indigo-600/30'
-                }`}
+                className={`${btnSize} rounded-full flex items-center justify-center shadow-2xl transition-[filter] hover:brightness-110`}
+                style={micStartButtonStyle(rgb, dk)}
                 title="録音開始"
               >
                 <Mic size={iconMic} />

--- a/Frontend/src/presentation/components/TestFeaturesPopover.tsx
+++ b/Frontend/src/presentation/components/TestFeaturesPopover.tsx
@@ -13,6 +13,8 @@ import { DEMO_TEXT_INSTANT } from '../../debug/demo/demo'
 import { useDemoTools } from '../context/DemoToolsContext'
 import { getTranscriptionService } from '../hooks/useTranscription'
 import { useDemoImportantMarkingStore } from '../../stores/demoImportantMarkingStore'
+import { useAccentTheme } from '../../theme/AccentThemeContext'
+import { accentRgbSolid, accentSliderStyle } from '../../theme/accentStyles'
 
 interface Props {
   darkMode?: boolean
@@ -34,6 +36,7 @@ export const TestFeaturesPopover: React.FC<Props> = ({ darkMode = true, align = 
   const demoStream = useDemoTools()
   const demoMarkingEnabled = useDemoImportantMarkingStore(s => s.enabled)
   const setDemoMarkingEnabled = useDemoImportantMarkingStore(s => s.setEnabled)
+  const { rgb } = useAccentTheme()
   const dk = darkMode
 
   const isStreaming = demoStream.status === 'playing'
@@ -114,7 +117,8 @@ export const TestFeaturesPopover: React.FC<Props> = ({ darkMode = true, align = 
                         role="switch"
                         aria-checked={demoMarkingEnabled}
                         onClick={() => setDemoMarkingEnabled(!demoMarkingEnabled)}
-                        className={`w-10 h-5 rounded-full shrink-0 relative transition-colors ${demoMarkingEnabled ? 'bg-indigo-600' : dk ? 'bg-slate-600' : 'bg-slate-200'}`}
+                        className={`w-10 h-5 rounded-full shrink-0 relative transition-colors ${demoMarkingEnabled ? '' : dk ? 'bg-slate-600' : 'bg-slate-200'}`}
+                        style={demoMarkingEnabled ? { backgroundColor: accentRgbSolid(rgb) } : undefined}
                       >
                         <span
                           className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-all ${demoMarkingEnabled ? 'left-[22px]' : 'left-0.5'}`}
@@ -208,8 +212,11 @@ export const TestFeaturesPopover: React.FC<Props> = ({ darkMode = true, align = 
                     step={1}
                     value={pos}
                     onChange={e => demoStream.setIntervalMs(posToMs(Number(e.target.value)))}
-                    className={`w-full h-1.5 rounded-full appearance-none cursor-pointer ${isStreaming ? 'accent-purple-500' : dk ? 'accent-slate-500' : 'accent-slate-400'}`}
-                    style={{ background: dk ? '#1e293b' : '#e2e8f0' }}
+                    className={`w-full h-1.5 rounded-full appearance-none cursor-pointer ${isStreaming ? 'accent-purple-500' : ''}`}
+                    style={{
+                      background: dk ? '#1e293b' : '#e2e8f0',
+                      ...(isStreaming ? {} : accentSliderStyle(rgb)),
+                    }}
                   />
                 </div>
               </div>

--- a/Frontend/src/presentation/layout/LayoutEngine.tsx
+++ b/Frontend/src/presentation/layout/LayoutEngine.tsx
@@ -162,11 +162,23 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
               </button>
             )}
           </div>
-          <div style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}>
-            {WindowComponent
-              ? <WindowComponent windowId={node.windowId} darkMode={darkMode} />
-              : <div className="p-4 text-sm text-slate-400">ウィンドウ未登録: {node.windowId}</div>
-            }
+          <div style={{ flex: 1, minHeight: 0, position: 'relative', overflow: 'hidden' }}>
+            <div className="relative z-0 h-full min-h-0 overflow-hidden">
+              {WindowComponent
+                ? <WindowComponent windowId={node.windowId} darkMode={darkMode} />
+                : <div className="p-4 text-sm text-slate-400">ウィンドウ未登録: {node.windowId}</div>
+              }
+            </div>
+            {/* テーマカラーのごく薄い背景ティント（コンテンツ上・操作は透過） */}
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 z-[1]"
+              style={{
+                background: darkMode
+                  ? `radial-gradient(115% 90% at 50% -5%, rgba(${accentRgb},0.13) 0%, rgba(${accentRgb},0.045) 38%, transparent 68%)`
+                  : `radial-gradient(110% 85% at 50% -5%, rgba(${accentRgb},0.1) 0%, rgba(${accentRgb},0.035) 42%, transparent 70%)`,
+              }}
+            />
           </div>
           {dragging !== null && dragging !== node.windowId && (
             <div

--- a/Frontend/src/presentation/layout/LayoutEngine.tsx
+++ b/Frontend/src/presentation/layout/LayoutEngine.tsx
@@ -8,15 +8,7 @@ import {
   SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
   SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
 } from '../constants/systemControlWindow'
-
-const ACCENT_RGB: Record<string, string> = {
-  blue: '59,130,246',
-  indigo: '99,102,241',
-  purple: '168,85,247',
-  rose: '244,63,94',
-  emerald: '16,185,129',
-  orange: '249,115,22',
-}
+import { getAccentRgb } from '../../theme/accentTokens'
 
 const DropOverlay: React.FC<{ zone: DropZone; rgb: string }> = ({ zone, rgb }) => {
   const base: React.CSSProperties = {
@@ -87,10 +79,13 @@ export interface LayoutEngineProps {
 export const LayoutEngine: React.FC<LayoutEngineProps> = ({
   layout, onLayoutChange, darkMode, themeColor = 'indigo', onClose,
 }) => {
-  const accentRgb = ACCENT_RGB[themeColor] ?? ACCENT_RGB['indigo']
-  const borderStyle = `2px solid rgba(${accentRgb},0.6)`
-  const headerBg = `rgba(${accentRgb},0.07)`
+  const accentRgb = getAccentRgb(themeColor)
+  const borderStyle = `2px solid rgba(${accentRgb},0.72)`
+  const headerBg = `rgba(${accentRgb},${darkMode ? 0.18 : 0.12})`
   const dotColor = `rgba(${accentRgb},1)`
+  const panelGlow = darkMode
+    ? `0 0 0 1px rgba(${accentRgb},0.14), 0 12px 40px rgba(${accentRgb},0.1)`
+    : `0 0 0 1px rgba(${accentRgb},0.18), 0 10px 36px rgba(${accentRgb},0.08)`
 
   const [dragging, setDragging] = useState<string | null>(null)
   const [dropInfo, setDropInfo] = useState<{ windowId: string; zone: DropZone } | null>(null)
@@ -143,6 +138,7 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
             position: 'relative', display: 'flex', flexDirection: 'column',
             width: '100%', height: '100%',
             overflow: 'hidden', border: borderStyle, borderRadius: 6,
+            boxShadow: panelGlow,
             ...leafMin,
           }}
         >
@@ -150,8 +146,8 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
             draggable
             onDragStart={e => { e.dataTransfer.effectAllowed = 'move'; setDragging(node.windowId) }}
             onDragEnd={() => { setDragging(null); setDropInfo(null) }}
-            className={`flex items-center gap-1.5 px-2.5 py-1 flex-shrink-0 cursor-grab active:cursor-grabbing select-none border-b ${darkMode ? 'text-slate-400 hover:text-slate-200' : 'text-slate-500 hover:text-slate-700'}`}
-            style={{ backgroundColor: headerBg, borderBottomColor: `rgba(${accentRgb},0.3)` }}
+            className={`flex items-center gap-1.5 px-2.5 py-1 flex-shrink-0 cursor-grab active:cursor-grabbing select-none border-b font-semibold ${darkMode ? 'text-slate-300 hover:text-white' : 'text-slate-600 hover:text-slate-900'}`}
+            style={{ backgroundColor: headerBg, borderBottomColor: `rgba(${accentRgb},0.42)` }}
           >
             <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: dotColor }} />
             <GripHorizontal size={10} className="opacity-40 flex-shrink-0" />
@@ -237,7 +233,7 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
       </div>
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dragging, dropInfo, darkMode, accentRgb, borderStyle, headerBg, dotColor, calcZone, onLayoutChange, onClose])
+  }, [dragging, dropInfo, darkMode, accentRgb, borderStyle, headerBg, dotColor, panelGlow, calcZone, onLayoutChange, onClose])
 
   return (
     <div style={{ width: '100%', height: '100%', overflow: 'hidden' }}>

--- a/Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx
+++ b/Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx
@@ -13,6 +13,8 @@ import {
 import type { WindowProps } from '../IWindowDefinition'
 import { useContentFontScaleStore } from '../../../stores/contentFontScaleStore'
 import { scaledContentFontPx } from '../../../app/utils/contentFontScale'
+import { useAccentTheme } from '../../../theme/AccentThemeContext'
+import { accentRgba, accentRgbSolid, accentSliderStyle } from '../../../theme/accentStyles'
 
 const RANK_THROTTLE_MS = 160
 const MIN_ROW_HEIGHT = 50
@@ -33,6 +35,7 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
   const togglePin = useTermStore(s => s.togglePin)
 
   const contentFontScale = useContentFontScaleStore(s => s.scale)
+  const { rgb } = useAccentTheme()
 
   const throttledTranscript = useThrottledValue(transcript, RANK_THROTTLE_MS)
   const throttledTerms = useThrottledValue(activeTerms as Term[], RANK_THROTTLE_MS)
@@ -102,9 +105,17 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
                 onClick={() => setFilterMode('all')}
                 className={`px-2 py-0.5 rounded text-[10px] font-bold transition-colors ${
                   filterMode === 'all'
-                    ? dk ? 'bg-indigo-500/30 text-indigo-200' : 'bg-indigo-100 text-indigo-700'
+                    ? ''
                     : dk ? 'text-slate-400 hover:text-slate-200' : 'text-slate-500 hover:text-slate-700'
                 }`}
+                style={
+                  filterMode === 'all'
+                    ? {
+                        backgroundColor: accentRgba(rgb, dk ? 0.32 : 0.14),
+                        color: accentRgba(rgb, dk ? 0.96 : 0.88),
+                      }
+                    : undefined
+                }
               >
                 重要度順
               </button>
@@ -130,8 +141,8 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
               step={1}
               value={rowSizeSlider}
               onChange={(e) => setRowSizeSlider(Number(e.target.value))}
-              className={`w-28 h-1.5 rounded-full appearance-none cursor-pointer ${dk ? 'accent-violet-400' : 'accent-violet-600'}`}
-              style={{ background: dk ? '#334155' : '#cbd5e1' }}
+              className="w-28 h-1.5 rounded-full appearance-none cursor-pointer"
+              style={{ background: dk ? '#334155' : '#cbd5e1', ...accentSliderStyle(rgb) }}
               title={`要素サイズ: ${rowSizeSlider}`}
             />
             <span className={`text-[10px] font-mono ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
@@ -180,11 +191,22 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
                       className="flex items-center gap-2 flex-1 min-w-0 text-left"
                     >
                       <span
-                        className={`w-8 h-8 shrink-0 rounded-full border text-center text-[12px] font-black leading-[30px] ${
+                        className="w-8 h-8 shrink-0 rounded-full border text-center text-[12px] font-black leading-[30px]"
+                        style={
                           dk
-                            ? 'text-indigo-100 border-indigo-300/70 bg-gradient-to-b from-indigo-500/80 to-indigo-700/80 shadow-[0_0_12px_rgba(99,102,241,0.45)]'
-                            : 'text-indigo-800 border-indigo-300 bg-gradient-to-b from-indigo-100 to-indigo-200 shadow-[0_1px_6px_rgba(79,70,229,0.22)]'
-                        }`}
+                            ? {
+                                color: accentRgba(rgb, 0.96),
+                                borderColor: accentRgba(rgb, 0.55),
+                                background: `linear-gradient(to bottom, ${accentRgba(rgb, 0.75)}, ${accentRgba(rgb, 0.45)})`,
+                                boxShadow: `0 0 14px ${accentRgba(rgb, 0.4)}`,
+                              }
+                            : {
+                                color: accentRgba(rgb, 0.95),
+                                borderColor: accentRgba(rgb, 0.4),
+                                background: `linear-gradient(to bottom, ${accentRgba(rgb, 0.18)}, ${accentRgba(rgb, 0.32)})`,
+                                boxShadow: `0 1px 8px ${accentRgba(rgb, 0.22)}`,
+                              }
+                        }
                       >
                         {index + 1}
                       </span>
@@ -203,8 +225,11 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
                         </span>
                         <span className={`mt-1 block h-1.5 w-full rounded-full ${dk ? 'bg-slate-700' : 'bg-slate-200'}`}>
                           <span
-                            className={`block h-1.5 rounded-full ${dk ? 'bg-indigo-400' : 'bg-indigo-500'}`}
-                            style={{ width: `${Math.max(8, Math.min(100, (row.score / maxVisibleScore) * 100))}%` }}
+                            className="block h-1.5 rounded-full"
+                            style={{
+                              width: `${Math.max(8, Math.min(100, (row.score / maxVisibleScore) * 100))}%`,
+                              backgroundColor: accentRgbSolid(rgb),
+                            }}
                           />
                         </span>
                       </span>

--- a/Frontend/src/presentation/windows/MinutesWindow/index.tsx
+++ b/Frontend/src/presentation/windows/MinutesWindow/index.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import { FileText, Loader2 } from 'lucide-react'
 import type { WindowProps } from '../IWindowDefinition'
+import { useAccentTheme } from '../../../theme/AccentThemeContext'
+import { accentRgba } from '../../../theme/accentStyles'
 
 export const MinutesWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const dk = darkMode
+  const { rgb } = useAccentTheme()
 
   return (
     <div className={`h-full flex flex-col items-center justify-center text-center p-8 gap-4 ${dk ? 'text-slate-400 bg-[#0d0e1a]' : 'text-slate-500 bg-white'}`}>
@@ -13,7 +16,11 @@ export const MinutesWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
         <p className="text-xs opacity-50">発表終了後、ボタンを押すと<br />AIが議事録を生成します</p>
       </div>
       <button
-        className={`mt-2 px-4 py-2 rounded-lg text-xs font-bold flex items-center gap-2 transition-colors ${dk ? 'bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/30' : 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200'}`}
+        className="mt-2 px-4 py-2 rounded-lg text-xs font-bold flex items-center gap-2 transition-[filter] hover:brightness-110"
+        style={{
+          backgroundColor: accentRgba(rgb, dk ? 0.22 : 0.12),
+          color: accentRgba(rgb, dk ? 0.95 : 0.88),
+        }}
         onClick={() => {
           // TODO: サーバーへのリクエスト実装
         }}

--- a/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
+++ b/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
@@ -9,13 +9,16 @@ import {
   SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
   SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
 } from '../../constants/systemControlWindow'
+import { useAccentTheme } from '../../../theme/AccentThemeContext'
+import { micStartButtonStyle } from '../../../theme/accentStyles'
 
 const focusRing =
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:ring-offset-2'
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--app-accent-rgb)/0.45)] focus-visible:ring-offset-2'
 
 export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const { onResetAll } = usePresentationShell()
   const dk = darkMode
+  const { rgb } = useAccentTheme()
   const ringOffset = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
 
   const { isListening, startListening, stopListening } = useTranscription()
@@ -67,11 +70,8 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
               exit={{ opacity: 0 }}
               transition={{ duration: 0.12 }}
               whileTap={{ scale: 0.98 }}
-              className={`${recordBtnBase} ${
-                dk
-                  ? 'bg-indigo-600 text-white shadow-indigo-600/30 hover:bg-indigo-500'
-                  : 'bg-indigo-600 text-white shadow-indigo-600/25 hover:bg-indigo-500'
-              }`}
+              className={`${recordBtnBase} text-white hover:brightness-110`}
+              style={micStartButtonStyle(rgb, dk)}
               title="録音開始"
             >
               <Mic size={16} strokeWidth={2.25} className="shrink-0" />

--- a/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
+++ b/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
@@ -9,16 +9,12 @@ import {
   SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
   SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
 } from '../../constants/systemControlWindow'
-import { useAccentTheme } from '../../../theme/AccentThemeContext'
-import { micStartButtonStyle } from '../../../theme/accentStyles'
-
 const focusRing =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--app-accent-rgb)/0.45)] focus-visible:ring-offset-2'
 
 export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const { onResetAll } = usePresentationShell()
   const dk = darkMode
-  const { rgb } = useAccentTheme()
   const ringOffset = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
 
   const { isListening, startListening, stopListening } = useTranscription()
@@ -54,10 +50,10 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
               exit={{ opacity: 0 }}
               transition={{ duration: 0.12 }}
               whileTap={{ scale: 0.98 }}
-              className={`${recordBtnBase} bg-red-500 text-white shadow-red-500/25 hover:bg-red-400`}
+              className={`${recordBtnBase} bg-emerald-500 text-white shadow-emerald-500/25 hover:bg-emerald-400`}
               title="録音を中断"
             >
-              <span className="pointer-events-none absolute inset-0 animate-ping rounded-lg bg-red-400 opacity-15" />
+              <span className="pointer-events-none absolute inset-0 animate-ping rounded-lg bg-emerald-400 opacity-15" />
               <Square size={16} fill="currentColor" className="shrink-0" />
               <span className="min-w-0 truncate">中断</span>
             </motion.button>
@@ -70,8 +66,7 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
               exit={{ opacity: 0 }}
               transition={{ duration: 0.12 }}
               whileTap={{ scale: 0.98 }}
-              className={`${recordBtnBase} text-white hover:brightness-110`}
-              style={micStartButtonStyle(rgb, dk)}
+              className={`${recordBtnBase} bg-violet-600 text-white shadow-violet-500/25 hover:bg-violet-500`}
               title="録音開始"
             >
               <Mic size={16} strokeWidth={2.25} className="shrink-0" />

--- a/Frontend/src/theme/AccentThemeContext.tsx
+++ b/Frontend/src/theme/AccentThemeContext.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useEffect, useMemo } from 'react'
+import { ACCENT_RGB, getAccentRgb } from './accentTokens'
+
+export type AccentThemeContextValue = {
+  themeKey: string
+  /** 例: "99,102,241" — `rgba(${rgb},a)` / `rgb(${rgb})` にそのまま使える */
+  rgb: string
+}
+
+const defaultValue: AccentThemeContextValue = {
+  themeKey: 'indigo',
+  rgb: ACCENT_RGB.indigo,
+}
+
+const AccentThemeContext = createContext<AccentThemeContextValue>(defaultValue)
+
+export function AccentThemeProvider({
+  themeColor,
+  children,
+}: {
+  themeColor: string
+  children: React.ReactNode
+}) {
+  const rgb = useMemo(() => getAccentRgb(themeColor), [themeColor])
+  const value = useMemo(
+    () => ({ themeKey: themeColor, rgb }),
+    [themeColor, rgb],
+  )
+
+  useEffect(() => {
+    const channels = rgb.split(',').map((s) => s.trim()).join(' ')
+    document.documentElement.style.setProperty('--app-accent-rgb', channels)
+    return () => {
+      document.documentElement.style.removeProperty('--app-accent-rgb')
+    }
+  }, [rgb])
+
+  return <AccentThemeContext.Provider value={value}>{children}</AccentThemeContext.Provider>
+}
+
+export function useAccentTheme(): AccentThemeContextValue {
+  return useContext(AccentThemeContext)
+}

--- a/Frontend/src/theme/accentStyles.ts
+++ b/Frontend/src/theme/accentStyles.ts
@@ -1,0 +1,41 @@
+import type { CSSProperties } from 'react'
+
+export function accentRgba(rgb: string, alpha: number): string {
+  return `rgba(${rgb},${alpha})`
+}
+
+export function accentRgbSolid(rgb: string): string {
+  return `rgb(${rgb})`
+}
+
+/** 文字起こし上の用語チップ・ピン表の語ボタンなど */
+export function termChipStyle(dk: boolean, rgb: string): CSSProperties {
+  if (dk) {
+    return {
+      backgroundColor: accentRgba(rgb, 0.26),
+      color: accentRgba(rgb, 0.98),
+      borderWidth: 1,
+      borderStyle: 'solid',
+      borderColor: accentRgba(rgb, 0.48),
+    }
+  }
+  return {
+    backgroundColor: accentRgba(rgb, 0.12),
+    color: accentRgba(rgb, 0.95),
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: accentRgba(rgb, 0.32),
+  }
+}
+
+export function micStartButtonStyle(rgb: string, dk: boolean): CSSProperties {
+  return {
+    backgroundColor: accentRgbSolid(rgb),
+    color: '#fff',
+    boxShadow: dk ? `0 12px 40px ${accentRgba(rgb, 0.42)}` : `0 10px 32px ${accentRgba(rgb, 0.28)}`,
+  }
+}
+
+export function accentSliderStyle(rgb: string): CSSProperties {
+  return { accentColor: accentRgbSolid(rgb) }
+}

--- a/Frontend/src/theme/accentTokens.ts
+++ b/Frontend/src/theme/accentTokens.ts
@@ -1,0 +1,15 @@
+/** SettingsModal / LayoutEngine と同一キー。値は CSS `rgb(r,g,b)` 用のカンマ区切りチャンネル。 */
+export const ACCENT_RGB: Record<string, string> = {
+  blue: '59,130,246',
+  indigo: '99,102,241',
+  purple: '168,85,247',
+  rose: '244,63,94',
+  emerald: '16,185,129',
+  orange: '249,115,22',
+}
+
+export type AccentThemeKey = keyof typeof ACCENT_RGB
+
+export function getAccentRgb(themeColor: string): string {
+  return ACCENT_RGB[themeColor] ?? ACCENT_RGB.indigo
+}


### PR DESCRIPTION
## 概要
ユーザーが選べるアクセントカラーに沿って、Lexical 向けプレゼンシェルと従来アプリ画面の見た目を統一しました。RGB トークン、React コンテキスト、スタイル用ヘルパーを追加し、境界線・シャドウ・スライダー・チップ・主要ボタンなどに反映しています。

## 主な内容
- **テーマ基盤:** `AccentThemeProvider`、CSS 変数、`accentStyles` などでアクセントを一箇所から供給。
- **レイアウトパネル:** 各リーフパネルの本文エリアに、アクセント色をほんのり載せたラディアルグラデーションを重ね、スウォッチ変更時に全体のトーンが揃うように調整。
- **録音 UI:** 録音開始は **バイオレット**、録音中（中断）は **エメラルド** の固定色にし、アクセント色と混同しないようにしています。

## ベースブランチ
`develop/v0` を向けています（本ブランチは `main` から大きく乖離しているため、レビューしやすい `develop/v0` との差分にしています）。

## 動作確認
- `cd Frontend && bun run build` がローカルで成功することを確認済みです。