### PR TITLE
fix(TermDetailPanel): 用語詳細のフック順エラーを修正

### DIFF
--- a/Frontend/src/app/components/TermDetailPanel.tsx
+++ b/Frontend/src/app/components/TermDetailPanel.tsx
@@ -26,6 +26,23 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
   const dk = darkMode;
   const contentFontScale = useContentFontScaleStore(s => s.scale);
   const { rgb } = useAccentTheme();
+  const [copied, setCopied] = useState<'word' | 'desc' | null>(null);
+
+  const copyWord = useCallback(() => {
+    if (!term) return;
+    void navigator.clipboard.writeText(term.word).then(() => {
+      setCopied('word');
+      setTimeout(() => setCopied(null), 800);
+    });
+  }, [term]);
+
+  const copyDesc = useCallback(() => {
+    if (!term) return;
+    void navigator.clipboard.writeText(term.longDesc).then(() => {
+      setCopied('desc');
+      setTimeout(() => setCopied(null), 800);
+    });
+  }, [term]);
 
   if (!term) {
     return (
@@ -47,21 +64,6 @@ export const TermDetailPanel: React.FC<TermDetailPanelProps> = ({
 
   const levelInfo = getLevelInfo(term.level);
   const related: Term[] = [];
-  const [copied, setCopied] = useState<'word' | 'desc' | null>(null);
-
-  const copyWord = useCallback(() => {
-    navigator.clipboard.writeText(term.word).then(() => {
-      setCopied('word');
-      setTimeout(() => setCopied(null), 800);
-    });
-  }, [term.word]);
-
-  const copyDesc = useCallback(() => {
-    navigator.clipboard.writeText(term.longDesc).then(() => {
-      setCopied('desc');
-      setTimeout(() => setCopied(null), 800);
-    });
-  }, [term.longDesc]);
 
   return (
     <div className={`h-full flex flex-col overflow-hidden ${dk ? 'bg-[#0d0e1a]' : 'bg-white'}`}>


### PR DESCRIPTION
## 概要
`term === null` のときに早期 return した後だけ `useState` / `useCallback` が実行され、用語クリック後にフックの本数が変わるため React の Rules of Hooks 違反になっていました（バブル・文字起こしウィンドウからのクリックで再現）。

## 対応
- すべてのフックを早期 return より上に移動
- コピー用コールバック内で `term` が無い場合は no-op

## 確認
- `cd Frontend && bun run build` が通ることを確認済みです。

Made with [Cursor](https://cursor.com)