### PR TITLE
feat(ux): 録音UI・ウィンドウ操作・情報過多の改善

### DIFF
--- a/Frontend/src/domain/interfaces/ITranscriptionService.ts
+++ b/Frontend/src/domain/interfaces/ITranscriptionService.ts
@@ -1,4 +1,4 @@
-export type TranscriptionStatus = 'idle' | 'listening' | 'error'
+export type TranscriptionStatus = 'idle' | 'listening' | 'paused' | 'error'
 export type TranscriptionMode = 'fast' | 'accurate'
 export type MicrophoneDevice = {
   deviceId: string
@@ -10,6 +10,7 @@ export interface ITranscriptionService {
   getTranscript(): string
   startListening(): void
   stopListening(): void
+  pauseListening(): void
   getAvailableMicrophones(): MicrophoneDevice[]
   getSelectedMicrophoneId(): string
   setSelectedMicrophone(deviceId: string): void

--- a/Frontend/src/infrastructure/speech/LocalSttTranscriptionService.ts
+++ b/Frontend/src/infrastructure/speech/LocalSttTranscriptionService.ts
@@ -8,6 +8,7 @@ export class LocalSttTranscriptionService implements ITranscriptionService {
   private transcript = ''
   private status: TranscriptionStatus = 'idle'
   private isRunning = false
+  private isPausing = false
   private microphones: MicrophoneDevice[] = []
   private selectedMicrophoneId = ''
   private selectedMicStream: MediaStream | null = null
@@ -125,6 +126,12 @@ export class LocalSttTranscriptionService implements ITranscriptionService {
           this.notify()
         }
         this.recorder.onstop = () => {
+          if (this.isPausing) {
+            this.isPausing = false
+            this.releaseResources()
+            this.chunks = []
+            return
+          }
           void this.transcribeRecordedAudio()
         }
         this.recorder.start()
@@ -146,6 +153,20 @@ export class LocalSttTranscriptionService implements ITranscriptionService {
     try {
       this.recorder?.stop()
     } catch {
+      this.releaseResources()
+    }
+  }
+
+  pauseListening(): void {
+    if (!this.isRunning) return
+    this.isPausing = true
+    this.isRunning = false
+    this.status = 'paused'
+    this.notify()
+    try {
+      this.recorder?.stop()
+    } catch {
+      this.isPausing = false
       this.releaseResources()
     }
   }

--- a/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
+++ b/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
@@ -264,6 +264,15 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
     this.notify()
   }
 
+  pauseListening(): void {
+    if (!this.recognition || !this.isRunning) return
+    this.isRunning = false
+    this.status = 'paused'
+    try { this.recognition.stop() } catch { /* ignore */ }
+    this.releaseSelectedMicrophone()
+    this.notify()
+  }
+
   clearTranscript(): void {
     this.transcript = ''
     this.finalTranscript = ''

--- a/Frontend/src/presentation/components/LayoutPresetMenu.tsx
+++ b/Frontend/src/presentation/components/LayoutPresetMenu.tsx
@@ -2,19 +2,12 @@ import React, { useEffect, useRef, useState } from 'react'
 import { LayoutGrid } from 'lucide-react'
 import { useLayoutStore } from '../../stores/layoutStore'
 import {
-  addUserWindowToDockedLayout,
-  attachSystemControlDock,
-  collectUserWindowIdsInLayout,
-  leafNode,
   makeDefaultLayout,
   makeLeftRightLayout,
   make2x2Layout,
   makeHorizontalLayout,
   makeVerticalLayout,
-  removeUserWindowFromDockedLayout,
 } from '../layout/layoutUtils'
-import { getLayoutSelectableWindows } from '../windows/registry'
-import { useAccentTheme } from '../../theme/AccentThemeContext'
 
 const PRESETS = [
   { key: 'default', label: 'デフォルト', make: makeDefaultLayout },
@@ -27,13 +20,8 @@ const PRESETS = [
 interface Props {
   darkMode?: boolean
   phaseId: string
-  /** ドロップダウンの水平位置（ヘッダー右寄せ時は right） */
   menuAlign?: 'left' | 'right'
-  /** true のとき表示は維持するが操作不可（発表後など） */
   disabled?: boolean
-  /** 操作ドックなど狭い場所向けの小さめトリガー */
-  compact?: boolean
-  /** アイコン横に「レイアウト」などのラベルを表示（ヘッダー用） */
   labeled?: boolean
 }
 
@@ -45,16 +33,14 @@ export const LayoutPresetMenu: React.FC<Props> = ({
   phaseId,
   menuAlign = 'right',
   disabled = false,
-  compact = false,
   labeled = false,
 }) => {
   const rootRef = useRef<HTMLDivElement>(null)
   const [open, setOpen] = useState(false)
-  const { rgb } = useAccentTheme()
   const setLayout = useLayoutStore(s => s.setLayout)
-  const layout = useLayoutStore(s => s.layouts[phaseId])
   const menuPos = menuAlign === 'right' ? 'right-0 left-auto' : 'left-0'
   const ringOffset = darkMode ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
+  const dk = darkMode
 
   useEffect(() => {
     if (disabled) setOpen(false)
@@ -71,110 +57,52 @@ export const LayoutPresetMenu: React.FC<Props> = ({
     return () => document.removeEventListener('pointerdown', onPointerDown, true)
   }, [open, disabled])
 
-  const toggle = () => {
-    if (!disabled) setOpen(v => !v)
-  }
-
-  const iconSize = compact ? 16 : labeled ? 17 : 18
-
-  const triggerIconOnly = `relative z-0 flex shrink-0 items-center justify-center rounded-full transition-colors ${compact ? 'size-9' : 'size-11'} ${focusRing} ${ringOffset} ${darkMode
-    ? 'text-slate-300 hover:bg-slate-800 hover:text-slate-100'
-    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'} ${disabled
-    ? 'pointer-events-none opacity-[0.42] saturate-50'
-    : ''}`
-
-  const triggerLabeled = `relative z-0 flex min-h-10 shrink-0 flex-row items-center gap-2 rounded-lg border px-3 py-2 text-sm font-bold transition-colors ${focusRing} ${ringOffset} ${darkMode
+  const triggerLabeled = `relative z-0 flex min-h-10 shrink-0 flex-row items-center gap-2 rounded-lg border px-3 py-2 text-sm font-bold transition-colors ${focusRing} ${ringOffset} ${dk
     ? 'border-slate-700/80 bg-slate-900/25 text-slate-200 hover:bg-slate-800'
     : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'} ${disabled
     ? 'pointer-events-none cursor-not-allowed opacity-[0.42] saturate-50'
     : ''}`
 
-  const selectable = getLayoutSelectableWindows()
-  const activeIds = layout ? collectUserWindowIdsInLayout(layout) : new Set<string>()
-  const sortByLabel = (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label, 'ja')
-  const checkedDefs = selectable.filter(d => activeIds.has(d.id)).sort(sortByLabel)
-  const uncheckedDefs = selectable.filter(d => !activeIds.has(d.id)).sort(sortByLabel)
-  const orderedWindowRows = [...checkedDefs, ...uncheckedDefs]
-
-  const applyWindowToggle = (windowId: string, checked: boolean) => {
-    const cur = useLayoutStore.getState().layouts[phaseId]
-    if (checked) {
-      if (!cur) setLayout(phaseId, attachSystemControlDock(leafNode(windowId)))
-      else setLayout(phaseId, addUserWindowToDockedLayout(cur, windowId))
-    } else {
-      if (!cur) return
-      setLayout(phaseId, removeUserWindowFromDockedLayout(cur, windowId))
-    }
-  }
-
-  const dk = darkMode
-  const rowHover = dk ? 'hover:bg-slate-800/80' : 'hover:bg-slate-50'
-  const chk = dk ? 'border-slate-600' : 'border-slate-300'
-
   return (
     <div
       ref={rootRef}
-      className={`relative inline-flex ${labeled ? 'rounded-lg' : 'rounded-full'} ${disabled ? 'cursor-not-allowed' : ''}`}
+      className={`relative inline-flex rounded-lg ${disabled ? 'cursor-not-allowed' : ''}`}
       title={disabled ? '発表中のみレイアウトを変更できます' : undefined}
     >
       <button
         type="button"
         disabled={disabled}
-        onClick={toggle}
-        aria-label={disabled ? 'レイアウト（発表後は利用不可）' : 'レイアウトとウィンドウ'}
+        onClick={() => { if (!disabled) setOpen(v => !v) }}
+        aria-label={disabled ? 'レイアウト（発表後は利用不可）' : 'レイアウトプリセット'}
         aria-expanded={!disabled && open}
         aria-disabled={disabled}
         aria-haspopup="true"
-        className={labeled ? triggerLabeled : triggerIconOnly}
+        className={triggerLabeled}
       >
-        <LayoutGrid size={iconSize} strokeWidth={2} />
+        <LayoutGrid size={17} strokeWidth={2} />
         {labeled ? <span className="whitespace-nowrap">レイアウト</span> : null}
       </button>
+
       {disabled ? (
         <span
-          className={`pointer-events-none absolute inset-0 z-10 flex items-center justify-center overflow-hidden ${labeled ? 'rounded-lg' : 'rounded-full'}`}
+          className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center overflow-hidden rounded-lg"
           aria-hidden
         >
-          <span
-            className={`absolute h-[2px] w-[140%] -rotate-[38deg] bg-current ${darkMode ? 'text-slate-500' : 'text-slate-600'}`}
-          />
+          <span className={`absolute h-[2px] w-[140%] -rotate-[38deg] bg-current ${dk ? 'text-slate-500' : 'text-slate-600'}`} />
         </span>
       ) : null}
+
       {!disabled && open && (
         <div
-          className={`absolute top-full ${menuPos} mt-1 z-[60] flex max-h-[min(70vh,420px)] w-[min(92vw,300px)] min-w-[260px] flex-col overflow-hidden rounded-lg border shadow-xl ${darkMode
+          className={`absolute top-full ${menuPos} mt-1 z-[60] w-[min(92vw,240px)] min-w-[200px] overflow-hidden rounded-lg border shadow-xl ${dk
             ? 'border-slate-700 bg-[#0d0e1a]'
             : 'border-slate-200 bg-white'}`}
           role="menu"
         >
-          <div className={`shrink-0 border-b px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wider ${dk ? 'border-slate-700 text-slate-500' : 'border-slate-200 text-slate-500'}`}>
-            ウィンドウ
-          </div>
-          <div className="min-h-0 flex-1 overflow-y-auto py-1">
-            {orderedWindowRows.map(def => (
-              <label
-                key={def.id}
-                className={`flex cursor-pointer items-center justify-between gap-3 px-3 py-2 text-xs font-medium ${rowHover} ${dk ? 'text-slate-200' : 'text-slate-800'}`}
-              >
-                <span className="min-w-0 flex-1 truncate">{def.label}</span>
-                <input
-                  type="checkbox"
-                  className={`size-4 shrink-0 rounded border ${chk}`}
-                  style={{ accentColor: `rgb(${rgb})` }}
-                  checked={activeIds.has(def.id)}
-                  onChange={e => {
-                    e.stopPropagation()
-                    applyWindowToggle(def.id, e.target.checked)
-                  }}
-                  aria-label={`${def.label}を表示`}
-                />
-              </label>
-            ))}
-          </div>
-          <div className={`shrink-0 border-t px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wider ${dk ? 'border-slate-700 text-slate-500' : 'border-slate-200 text-slate-500'}`}>
+          <div className={`border-b px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wider ${dk ? 'border-slate-700 text-slate-500' : 'border-slate-200 text-slate-500'}`}>
             レイアウトテンプレート
           </div>
-          <div className="max-h-44 overflow-y-auto py-1">
+          <div className="py-1">
             {PRESETS.map(p => (
               <button
                 key={p.key}
@@ -184,7 +112,7 @@ export const LayoutPresetMenu: React.FC<Props> = ({
                   setLayout(phaseId, p.make())
                   setOpen(false)
                 }}
-                className={`w-full px-3 py-1.5 text-left text-xs transition-colors ${darkMode
+                className={`w-full px-3 py-2 text-left text-xs font-medium transition-colors ${dk
                   ? 'text-slate-300 hover:bg-slate-800'
                   : 'text-slate-700 hover:bg-slate-50'}`}
               >

--- a/Frontend/src/presentation/components/PhaseTransitionButton.tsx
+++ b/Frontend/src/presentation/components/PhaseTransitionButton.tsx
@@ -5,7 +5,7 @@ import { useBubbleStore } from '../../stores/bubbleStore'
 
 interface Props {
   darkMode?: boolean
-  /** 操作ドック内: 録音ボタンと横並びの低いボタン */
+  /** 操作ドック内: 録音ボタンの下に配置する従属ボタン */
   compact?: boolean
 }
 
@@ -13,6 +13,7 @@ export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compac
   const currentPhaseId = usePhaseStore(s => s.currentPhaseId)
   const transitionTo = usePhaseStore(s => s.transitionTo)
   const clearBubbles = useBubbleStore(s => s.clearBubbles)
+  const dk = darkMode
 
   const isDuring = currentPhaseId === 'during'
 
@@ -25,20 +26,48 @@ export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compac
     }
   }
 
-  const ringOffset = darkMode ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
-  const focusRing = isDuring
-    ? 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400/70 focus-visible:ring-offset-2'
-    : 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 focus-visible:ring-offset-2'
+  const focusRing = 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2'
+  const ringOffset = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
+
+  if (compact) {
+    const outlineCls = isDuring
+      ? dk
+        ? 'border-rose-500/50 text-rose-400 hover:bg-rose-500/15 focus-visible:ring-rose-400/60'
+        : 'border-rose-400 text-rose-600 bg-rose-50 hover:bg-rose-100 focus-visible:ring-rose-400/60'
+      : dk
+        ? 'border-emerald-500/50 text-emerald-400 hover:bg-emerald-500/15 focus-visible:ring-emerald-400/60'
+        : 'border-emerald-400 text-emerald-700 bg-emerald-50 hover:bg-emerald-100 focus-visible:ring-emerald-400/60'
+
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        title={isDuring ? '発表を終了する' : '発表中に戻る'}
+        aria-label={isDuring ? '発表を終了する' : '発表中に戻る'}
+        className={`inline-flex w-full items-center justify-center gap-1.5 rounded-lg border px-2.5 py-2 text-xs font-bold transition-colors active:scale-[0.98] ${outlineCls} ${focusRing} ${ringOffset}`}
+      >
+        {isDuring ? (
+          <>
+            <StopCircle size={14} strokeWidth={2.25} className="shrink-0" />
+            <span className="min-w-0 truncate">発表終了</span>
+          </>
+        ) : (
+          <>
+            <Play size={14} strokeWidth={2.25} className="shrink-0" />
+            <span className="min-w-0 truncate">もどる</span>
+          </>
+        )}
+      </button>
+    )
+  }
 
   const surface = isDuring
-    ? darkMode
-      ? 'bg-gradient-to-b from-rose-500 to-rose-700 text-white shadow-rose-900/40 hover:from-rose-400 hover:to-rose-600'
-      : 'bg-gradient-to-b from-rose-500 to-rose-600 text-white shadow-rose-900/25 hover:from-rose-600 hover:to-rose-700'
-    : darkMode
-      ? 'bg-gradient-to-b from-emerald-500 to-emerald-700 text-white shadow-emerald-900/40 hover:from-emerald-400 hover:to-emerald-600'
-      : 'bg-gradient-to-b from-emerald-500 to-emerald-600 text-white shadow-emerald-900/25 hover:from-emerald-600 hover:to-emerald-700'
-
-  const iconSize = compact ? 16 : 22
+    ? dk
+      ? 'bg-gradient-to-b from-rose-500 to-rose-700 text-white shadow-rose-900/40 hover:from-rose-400 hover:to-rose-600 focus-visible:ring-rose-400/70'
+      : 'bg-gradient-to-b from-rose-500 to-rose-600 text-white shadow-rose-900/25 hover:from-rose-600 hover:to-rose-700 focus-visible:ring-rose-400/70'
+    : dk
+      ? 'bg-gradient-to-b from-emerald-500 to-emerald-700 text-white shadow-emerald-900/40 hover:from-emerald-400 hover:to-emerald-600 focus-visible:ring-emerald-400/70'
+      : 'bg-gradient-to-b from-emerald-500 to-emerald-600 text-white shadow-emerald-900/25 hover:from-emerald-600 hover:to-emerald-700 focus-visible:ring-emerald-400/70'
 
   return (
     <button
@@ -46,20 +75,16 @@ export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compac
       onClick={handleClick}
       title={isDuring ? '発表を終了する' : '発表中に戻る'}
       aria-label={isDuring ? '発表を終了する' : '発表中に戻る'}
-      className={`inline-flex items-center justify-center font-bold leading-none shadow-md transition-transform active:scale-[0.98] ${
-        compact
-          ? 'min-h-11 h-11 min-w-0 flex-1 flex-row gap-1.5 rounded-lg px-2.5 text-[11px] hover:scale-[1.01]'
-          : 'w-full h-[3.25rem] shrink-0 gap-2.5 rounded-xl px-6 text-sm whitespace-nowrap shadow-lg hover:scale-[1.01]'
-      } ${focusRing} ${ringOffset} ${surface}`}
+      className={`inline-flex h-[3.25rem] w-full shrink-0 items-center justify-center gap-2.5 rounded-xl px-6 text-sm font-bold leading-none shadow-lg transition-transform active:scale-[0.98] hover:scale-[1.01] ${surface} ${focusRing} ${ringOffset}`}
     >
       {isDuring ? (
         <>
-          <StopCircle size={iconSize} strokeWidth={2.25} className="shrink-0" />
+          <StopCircle size={22} strokeWidth={2.25} className="shrink-0" />
           <span className="min-w-0 truncate">発表終了</span>
         </>
       ) : (
         <>
-          <Play size={iconSize} strokeWidth={2.25} className="shrink-0" />
+          <Play size={22} strokeWidth={2.25} className="shrink-0" />
           <span className="min-w-0 truncate">もどる</span>
         </>
       )}

--- a/Frontend/src/presentation/components/PresentationAppHeader.tsx
+++ b/Frontend/src/presentation/components/PresentationAppHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Settings } from 'lucide-react'
 import { LayoutPresetMenu } from './LayoutPresetMenu'
+import { WindowPickerButton } from './WindowPickerButton'
 import { TestFeaturesPopover } from './TestFeaturesPopover'
 import { useAccentTheme } from '../../theme/AccentThemeContext'
 import { accentRgba } from '../../theme/accentStyles'
@@ -14,9 +15,6 @@ export interface PresentationAppHeaderProps {
 const focusRing =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--app-accent-rgb)/0.45)] focus-visible:ring-offset-2'
 
-/**
- * プレゼンレイヤのヘッダー（ブランド・フェーズ・レイアウト・設定・開発テスト）。
- */
 export const PresentationAppHeader: React.FC<PresentationAppHeaderProps> = ({
   darkMode,
   currentPhaseId,
@@ -64,6 +62,7 @@ export const PresentationAppHeader: React.FC<PresentationAppHeaderProps> = ({
       </div>
 
       <div className="flex shrink-0 flex-wrap items-center justify-end gap-2" aria-label="ツールバー">
+        <WindowPickerButton darkMode={dk} phaseId="during" menuAlign="right" disabled={!isDuring} labeled />
         <LayoutPresetMenu darkMode={dk} phaseId="during" menuAlign="right" disabled={!isDuring} labeled />
         <button
           type="button"

--- a/Frontend/src/presentation/components/WindowPickerButton.tsx
+++ b/Frontend/src/presentation/components/WindowPickerButton.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { Layers } from 'lucide-react'
+import { useLayoutStore } from '../../stores/layoutStore'
+import {
+  addUserWindowToDockedLayout,
+  attachSystemControlDock,
+  collectUserWindowIdsInLayout,
+  leafNode,
+  removeUserWindowFromDockedLayout,
+} from '../layout/layoutUtils'
+import { getLayoutSelectableWindows } from '../windows/registry'
+import { useAccentTheme } from '../../theme/AccentThemeContext'
+
+interface Props {
+  darkMode?: boolean
+  phaseId: string
+  menuAlign?: 'left' | 'right'
+  disabled?: boolean
+  labeled?: boolean
+}
+
+const focusRing =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--app-accent-rgb)/0.45)] focus-visible:ring-offset-2'
+
+export const WindowPickerButton: React.FC<Props> = ({
+  darkMode = true,
+  phaseId,
+  menuAlign = 'right',
+  disabled = false,
+  labeled = false,
+}) => {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const [open, setOpen] = useState(false)
+  const { rgb } = useAccentTheme()
+  const setLayout = useLayoutStore(s => s.setLayout)
+  const layout = useLayoutStore(s => s.layouts[phaseId])
+  const menuPos = menuAlign === 'right' ? 'right-0 left-auto' : 'left-0'
+  const ringOffset = darkMode ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
+  const dk = darkMode
+
+  const selectable = getLayoutSelectableWindows()
+  const activeIds = layout ? collectUserWindowIdsInLayout(layout) : new Set<string>()
+  const activeCount = activeIds.size
+
+  const sortByLabel = (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label, 'ja')
+  const checkedDefs = selectable.filter(d => activeIds.has(d.id)).sort(sortByLabel)
+  const uncheckedDefs = selectable.filter(d => !activeIds.has(d.id)).sort(sortByLabel)
+  const orderedRows = [...checkedDefs, ...uncheckedDefs]
+
+  useEffect(() => {
+    if (disabled) setOpen(false)
+  }, [disabled])
+
+  useEffect(() => {
+    if (!open || disabled) return
+    const onPointerDown = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown, true)
+    return () => document.removeEventListener('pointerdown', onPointerDown, true)
+  }, [open, disabled])
+
+  const applyToggle = (windowId: string, checked: boolean) => {
+    const cur = useLayoutStore.getState().layouts[phaseId]
+    if (checked) {
+      if (!cur) setLayout(phaseId, attachSystemControlDock(leafNode(windowId)))
+      else setLayout(phaseId, addUserWindowToDockedLayout(cur, windowId))
+    } else {
+      if (!cur) return
+      setLayout(phaseId, removeUserWindowFromDockedLayout(cur, windowId))
+    }
+  }
+
+  const triggerCls = `relative z-0 flex min-h-10 shrink-0 flex-row items-center gap-2 rounded-lg border px-3 py-2 text-sm font-bold transition-colors ${focusRing} ${ringOffset} ${dk
+    ? 'border-slate-700/80 bg-slate-900/25 text-slate-200 hover:bg-slate-800'
+    : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'} ${disabled
+    ? 'pointer-events-none cursor-not-allowed opacity-[0.42] saturate-50'
+    : ''}`
+
+  return (
+    <div
+      ref={rootRef}
+      className={`relative inline-flex rounded-lg ${disabled ? 'cursor-not-allowed' : ''}`}
+      title={disabled ? '発表中のみウィンドウを変更できます' : undefined}
+    >
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => { if (!disabled) setOpen(v => !v) }}
+        aria-label={disabled ? 'ウィンドウ（発表後は利用不可）' : 'ウィンドウの表示切替'}
+        aria-expanded={!disabled && open}
+        aria-disabled={disabled}
+        aria-haspopup="true"
+        className={triggerCls}
+      >
+        <Layers size={17} strokeWidth={2} />
+        {labeled ? <span className="whitespace-nowrap">ウィンドウ</span> : null}
+        {activeCount > 0 && (
+          <span
+            className="flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-black text-white"
+            style={{ backgroundColor: `rgb(${rgb})` }}
+            aria-label={`${activeCount}個表示中`}
+          >
+            {activeCount}
+          </span>
+        )}
+      </button>
+
+      {disabled ? (
+        <span
+          className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center overflow-hidden rounded-lg"
+          aria-hidden
+        >
+          <span className={`absolute h-[2px] w-[140%] -rotate-[38deg] bg-current ${dk ? 'text-slate-500' : 'text-slate-600'}`} />
+        </span>
+      ) : null}
+
+      {!disabled && open && (
+        <div
+          className={`absolute top-full ${menuPos} mt-1 z-[60] w-[min(92vw,260px)] min-w-[220px] overflow-hidden rounded-lg border shadow-xl ${dk
+            ? 'border-slate-700 bg-[#0d0e1a]'
+            : 'border-slate-200 bg-white'}`}
+          role="menu"
+        >
+          <div className={`border-b px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wider ${dk ? 'border-slate-700 text-slate-500' : 'border-slate-200 text-slate-500'}`}>
+            ウィンドウ表示
+          </div>
+          <div className="py-1">
+            {orderedRows.map(def => {
+              const isActive = activeIds.has(def.id)
+              return (
+                <label
+                  key={def.id}
+                  className={`flex cursor-pointer items-center justify-between gap-3 px-3 py-2 text-xs font-medium transition-colors ${dk ? 'text-slate-200 hover:bg-slate-800/80' : 'text-slate-800 hover:bg-slate-50'}`}
+                >
+                  <span className="flex min-w-0 flex-1 items-center gap-2">
+                    <span
+                      className="h-1.5 w-1.5 shrink-0 rounded-full transition-colors"
+                      style={{ backgroundColor: isActive ? `rgb(${rgb})` : (dk ? 'rgb(71,85,105)' : 'rgb(203,213,225)') }}
+                    />
+                    <span className="truncate">{def.label}</span>
+                  </span>
+                  <input
+                    type="checkbox"
+                    className="size-4 shrink-0 rounded border"
+                    style={{ accentColor: `rgb(${rgb})` }}
+                    checked={isActive}
+                    onChange={e => {
+                      e.stopPropagation()
+                      applyToggle(def.id, e.target.checked)
+                    }}
+                    aria-label={`${def.label}を表示`}
+                  />
+                </label>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/Frontend/src/presentation/hooks/useTranscription.ts
+++ b/Frontend/src/presentation/hooks/useTranscription.ts
@@ -92,6 +92,7 @@ export function useTranscription() {
     transcript,
     status,
     isListening: status === 'listening',
+    isPaused: status === 'paused',
     microphones,
     selectedMicrophoneId,
     refreshMicrophones: () => void getTranscriptionService().refreshMicrophones(),
@@ -104,6 +105,9 @@ export function useTranscription() {
     },
     stopListening: () => {
       getTranscriptionService().stopListening()
+    },
+    pauseListening: () => {
+      getTranscriptionService().pauseListening()
     },
     clearTranscript: () => {
       getTranscriptionService().clearTranscript()

--- a/Frontend/src/presentation/layout/LayoutEngine.tsx
+++ b/Frontend/src/presentation/layout/LayoutEngine.tsx
@@ -146,12 +146,12 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
             draggable
             onDragStart={e => { e.dataTransfer.effectAllowed = 'move'; setDragging(node.windowId) }}
             onDragEnd={() => { setDragging(null); setDropInfo(null) }}
-            className={`flex items-center gap-1.5 px-2.5 py-1 flex-shrink-0 cursor-grab active:cursor-grabbing select-none border-b font-semibold ${darkMode ? 'text-slate-300 hover:text-white' : 'text-slate-600 hover:text-slate-900'}`}
+            className={`group flex items-center gap-1.5 px-2.5 py-2 flex-shrink-0 cursor-grab active:cursor-grabbing select-none border-b font-semibold transition-colors ${darkMode ? 'text-slate-300 hover:text-white hover:bg-white/5' : 'text-slate-600 hover:text-slate-900 hover:bg-black/5'}`}
             style={{ backgroundColor: headerBg, borderBottomColor: `rgba(${accentRgb},0.42)` }}
           >
             <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: dotColor }} />
-            <GripHorizontal size={10} className="opacity-40 flex-shrink-0" />
-            <span className="text-[9px] font-bold uppercase tracking-[0.15em]">{label}</span>
+            <GripHorizontal size={14} className="opacity-35 flex-shrink-0 transition-all group-hover:opacity-75 group-hover:scale-110" />
+            <span className="text-[10px] font-bold uppercase tracking-[0.12em]">{label}</span>
             {onClose && closable && (
               <button
                 onClick={e => { e.stopPropagation(); onClose(node.windowId) }}

--- a/Frontend/src/presentation/layout/layoutUtils.ts
+++ b/Frontend/src/presentation/layout/layoutUtils.ts
@@ -14,12 +14,7 @@ export function attachSystemControlDock(inner: LayoutNode, dockRatio = 0.18): La
 // ── 発表中フェーズのデフォルトレイアウト ──
 export const makeDefaultLayout = (): LayoutNode =>
   attachSystemControlDock(
-    S(
-      'h',
-      0.36,
-      L('transcription'),
-      S('h', 0.54, L('bubbleCloud'), S('v', 0.44, L('detail'), S('v', 0.5, L('importanceRanking'), L('history')))),
-    ),
+    S('h', 0.45, L('transcription'), L('bubbleCloud')),
   )
 
 export const makeLeftRightLayout = (): LayoutNode =>

--- a/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
+++ b/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
-import { Mic, Square, RotateCcw } from 'lucide-react'
+import { Mic, Pause, Play, RotateCcw, AlertTriangle } from 'lucide-react'
+import * as AlertDialog from '@radix-ui/react-alert-dialog'
 import { PhaseTransitionButton } from '../../components/PhaseTransitionButton'
 import { usePresentationShell } from '../../context/PresentationShellContext'
 import { useTranscription } from '../../hooks/useTranscription'
@@ -9,25 +10,22 @@ import {
   SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
   SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
 } from '../../constants/systemControlWindow'
+
 const focusRing =
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--app-accent-rgb)/0.45)] focus-visible:ring-offset-2'
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2'
 
 export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const { onResetAll } = usePresentationShell()
   const dk = darkMode
-  const ringOffset = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
+  const [resetOpen, setResetOpen] = useState(false)
 
-  const { isListening, startListening, stopListening } = useTranscription()
+  const { isListening, isPaused, startListening, pauseListening } = useTranscription()
 
-  const handleToggleListening = () => {
-    if (isListening) stopListening()
-    else startListening()
-  }
-
+  const ringOffsetCls = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
   const divider = dk ? 'bg-slate-700/40' : 'bg-slate-200'
 
-  const recordBtnBase =
-    'relative flex min-h-11 h-11 min-w-0 flex-1 flex-row items-center justify-center gap-2 rounded-lg px-2.5 text-[11px] font-bold shadow-md'
+  const primaryBtnBase =
+    'relative flex h-12 min-h-12 w-full flex-row items-center justify-center gap-2 rounded-lg text-xs font-bold shadow-md transition-transform active:scale-[0.98]'
 
   return (
     <div
@@ -39,34 +37,50 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
         dk ? 'bg-[#0d0e1a] text-slate-200' : 'bg-white text-slate-800'
       }`}
     >
-      <section aria-label="録音と発表の切り替え" className="flex gap-2">
+      {/* 録音コントロール（最優先） */}
+      <section aria-label="録音コントロール" className="flex flex-col gap-1.5">
         <AnimatePresence mode="wait">
           {isListening ? (
             <motion.button
-              key="stop"
-              onClick={handleToggleListening}
+              key="pause"
+              onClick={pauseListening}
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.12 }}
               whileTap={{ scale: 0.98 }}
-              className={`${recordBtnBase} bg-emerald-500 text-white shadow-emerald-500/25 hover:bg-emerald-400`}
-              title="録音を中断"
+              className={`${primaryBtnBase} bg-amber-500 text-white shadow-amber-900/30 hover:bg-amber-400 ${focusRing} focus-visible:ring-amber-400/60 ${ringOffsetCls}`}
+              title="録音を一時停止"
             >
-              <span className="pointer-events-none absolute inset-0 animate-ping rounded-lg bg-emerald-400 opacity-15" />
-              <Square size={16} fill="currentColor" className="shrink-0" />
-              <span className="min-w-0 truncate">中断</span>
+              <span className="pointer-events-none absolute inset-0 animate-ping rounded-lg bg-amber-400 opacity-15" />
+              <Pause size={16} fill="currentColor" className="shrink-0" />
+              <span className="min-w-0 truncate">一時停止</span>
+            </motion.button>
+          ) : isPaused ? (
+            <motion.button
+              key="resume"
+              onClick={startListening}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.12 }}
+              whileTap={{ scale: 0.98 }}
+              className={`${primaryBtnBase} bg-emerald-600 text-white shadow-emerald-900/30 hover:bg-emerald-500 ${focusRing} focus-visible:ring-emerald-400/60 ${ringOffsetCls}`}
+              title="録音を再開"
+            >
+              <Play size={16} fill="currentColor" className="shrink-0" />
+              <span className="min-w-0 truncate">再開</span>
             </motion.button>
           ) : (
             <motion.button
               key="start"
-              onClick={handleToggleListening}
+              onClick={startListening}
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.12 }}
               whileTap={{ scale: 0.98 }}
-              className={`${recordBtnBase} bg-violet-600 text-white shadow-violet-500/25 hover:bg-violet-500`}
+              className={`${primaryBtnBase} bg-emerald-500 text-white shadow-emerald-900/30 hover:bg-emerald-400 ${focusRing} focus-visible:ring-emerald-400/60 ${ringOffsetCls}`}
               title="録音開始"
             >
               <Mic size={16} strokeWidth={2.25} className="shrink-0" />
@@ -75,25 +89,74 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
           )}
         </AnimatePresence>
 
+        {/* 発表終了（録音コントロールより視覚的に従属） */}
         <PhaseTransitionButton darkMode={darkMode} compact />
       </section>
 
       <div className={`h-px shrink-0 ${divider}`} role="presentation" />
 
-      <button
-        type="button"
-        onClick={onResetAll}
-        title="文字起こし・用語・履歴などをすべてクリアします"
-        className={`flex w-full min-w-0 flex-row items-center justify-center gap-2 rounded-md border px-3 py-2 text-xs font-bold transition-colors ${
-          dk
-            ? 'border-amber-500/40 bg-amber-500/12 text-amber-300 hover:bg-amber-500/22'
-            : 'border-amber-300/90 bg-amber-50 text-amber-900 hover:bg-amber-100'
-        } ${focusRing} ${ringOffset}`}
-        aria-label="すべてリセット"
-      >
-        <RotateCcw size={15} strokeWidth={2.5} className="shrink-0" />
-        リセット
-      </button>
+      {/* リセット（確認ダイアログ付き） */}
+      <AlertDialog.Root open={resetOpen} onOpenChange={setResetOpen}>
+        <AlertDialog.Trigger asChild>
+          <button
+            type="button"
+            title="文字起こし・用語・履歴などをすべてクリアします"
+            className={`flex w-full min-w-0 flex-row items-center justify-center gap-2 rounded-md border px-3 py-2 text-xs font-bold transition-colors ${focusRing} focus-visible:ring-amber-400/60 ${ringOffsetCls} ${
+              dk
+                ? 'border-amber-500/40 bg-amber-500/12 text-amber-300 hover:bg-amber-500/22'
+                : 'border-amber-300/90 bg-amber-50 text-amber-900 hover:bg-amber-100'
+            }`}
+            aria-label="すべてリセット"
+          >
+            <RotateCcw size={14} strokeWidth={2.5} className="shrink-0" />
+            リセット
+          </button>
+        </AlertDialog.Trigger>
+
+        <AlertDialog.Portal>
+          <AlertDialog.Overlay className="fixed inset-0 z-[100] bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
+          <AlertDialog.Content
+            className={`fixed left-1/2 top-1/2 z-[101] w-[min(92vw,380px)] -translate-x-1/2 -translate-y-1/2 rounded-xl border p-5 shadow-2xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ${
+              dk
+                ? 'border-slate-700 bg-[#0d0e1a] text-slate-100'
+                : 'border-slate-200 bg-white text-slate-900'
+            }`}
+          >
+            <div className="mb-3 flex items-center gap-2.5">
+              <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${dk ? 'bg-amber-500/15 text-amber-400' : 'bg-amber-100 text-amber-600'}`}>
+                <AlertTriangle size={18} strokeWidth={2} />
+              </span>
+              <AlertDialog.Title className="text-sm font-bold">
+                本当にリセットしますか？
+              </AlertDialog.Title>
+            </div>
+            <AlertDialog.Description className={`text-xs leading-relaxed ${dk ? 'text-slate-400' : 'text-slate-500'}`}>
+              文字起こし・用語・バブル・履歴がすべて消去されます。この操作は元に戻せません。
+            </AlertDialog.Description>
+            <div className="mt-4 flex justify-end gap-2">
+              <AlertDialog.Cancel asChild>
+                <button
+                  className={`rounded-md border px-4 py-1.5 text-xs font-bold transition-colors ${
+                    dk
+                      ? 'border-slate-600 text-slate-300 hover:bg-slate-800'
+                      : 'border-slate-300 text-slate-700 hover:bg-slate-50'
+                  }`}
+                >
+                  キャンセル
+                </button>
+              </AlertDialog.Cancel>
+              <AlertDialog.Action asChild>
+                <button
+                  onClick={onResetAll}
+                  className="rounded-md bg-red-600 px-4 py-1.5 text-xs font-bold text-white transition-colors hover:bg-red-500"
+                >
+                  リセットする
+                </button>
+              </AlertDialog.Action>
+            </div>
+          </AlertDialog.Content>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
     </div>
   )
 }


### PR DESCRIPTION
## 概要

発表中フェーズのUXに関する6つの課題を解消します。

## 変更内容

### 1. 録音の一時停止・再開
- `TranscriptionStatus` に `'paused'` を追加
- `pauseListening()` を `ITranscriptionService` に定義し、WebSpeech・LocalStt 両サービスで実装
- 録音ボタンが **録音 → 一時停止 → 再開** の3状態に対応

### 2. リセット操作の保護
- リセットボタン押下時に Radix AlertDialog で確認ダイアログを表示
- 「キャンセル」または「リセットする」で明示的に操作を確定

### 3. ボタンの視覚的階層整理
- 録音コントロールを縦積みレイアウトの最上部（h-12 全幅）に配置し最優先に
- 発表終了ボタンを compact モードでアウトラインスタイルに変更し視覚的に従属
- 録音・一時停止・再開の色はテーマカラーに依存しない固定色（emerald / amber）

### 4. ウィンドウヘッダーのドラッグ操作発見性改善
- ヘッダーの縦パディングを拡大（`py-1` → `py-2`）しドラッグ領域を確保
- GripHorizontal アイコンをホバー時にアニメーション表示（opacity・scale）

### 5. ウィンドウ管理UIの分離
- **ウィンドウボタン**（新規）: 各ウィンドウのオン/オフを切替。アクティブ数バッジ付き
- **レイアウトボタン**: 開発者推奨テンプレートのみを表示するよう整理

### 6. デフォルトレイアウトの簡略化
- 初期表示を5ウィンドウから **文字起こし + バブルクラウド** の2ウィンドウに変更
- 追加ウィンドウはヘッダーの「ウィンドウ」ボタンから随時追加可能

## テスト手順

- [ ] 録音ボタンを押すと「一時停止」になること
- [ ] 一時停止後「再開」で文字起こしが継続されること
- [ ] リセットボタン押下で確認ダイアログが表示されること
- [ ] キャンセルでデータが消えないこと
- [ ] 「リセットする」でデータがクリアされること
- [ ] ウィンドウボタンからウィンドウのオン/オフが切替できること
- [ ] レイアウトボタンにテンプレートのみ表示されること
- [ ] 初期レイアウトが2ウィンドウで表示されること
- [ ] ウィンドウヘッダーをホバーするとグリップアイコンがアニメーションすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)