### PR TITLE
test(frontend): 自動テスト・仕様書（test-spec-003）と develop/v0 同期

### DIFF
--- a/Frontend/AGENTS.md
+++ b/Frontend/AGENTS.md
@@ -13,7 +13,7 @@
 | 推奨 | `Frontend/docs/orders/order-002.md` | ツールバー・デモ重要語・グローバルリセット等の追補指示 |
 | 必須 | `Frontend/docs/ADRs/` | 技術・設計の意思決定記録 |
 | 推奨 | `Frontend/docs/ADRs/adr-008.md` | プレゼンヘッダー・フェーズ遷移ボタン・発表後アクセント色の方針 |
-| 補足 | `Frontend/docs/tests/` | テスト仕様・結果 |
+| 補足 | `Frontend/docs/tests/` | テスト仕様・結果（`test-spec-001.md` 〜） |
 
 ---
 

--- a/Frontend/bun.lock
+++ b/Frontend/bun.lock
@@ -55,7 +55,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
+        "@happy-dom/global-registrator": "^20.9.0",
         "@tailwindcss/vite": "^4.0.9",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22.13.5",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -65,6 +67,7 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^15.15.0",
+        "happy-dom": "^20.9.0",
         "tailwindcss": "^4.0.9",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.24.1",
@@ -196,6 +199,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.7", "", { "dependencies": { "@floating-ui/dom": "^1.7.5" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -407,6 +412,12 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.1.18", "", { "dependencies": { "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "tailwindcss": "4.1.18" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -443,6 +454,10 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.0", "@typescript-eslint/type-utils": "8.56.0", "@typescript-eslint/utils": "8.56.0", "@typescript-eslint/visitor-keys": "8.56.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.56.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.56.0", "@typescript-eslint/types": "8.56.0", "@typescript-eslint/typescript-estree": "8.56.0", "@typescript-eslint/visitor-keys": "8.56.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg=="],
@@ -473,11 +488,15 @@
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "balanced-match": ["balanced-match@4.0.3", "", {}, "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g=="],
 
@@ -541,9 +560,13 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
@@ -556,6 +579,8 @@
     "embla-carousel-reactive-utils": ["embla-carousel-reactive-utils@8.6.0", "", { "peerDependencies": { "embla-carousel": "8.6.0" } }, "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": "bin/esbuild" }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -616,6 +641,8 @@
     "globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -693,6 +720,8 @@
 
     "lucide-react": ["lucide-react@0.475.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "minimatch": ["minimatch@10.2.1", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A=="],
@@ -734,6 +763,8 @@
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
@@ -825,9 +856,13 @@
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -874,6 +909,10 @@
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.0", "", {}, "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
   }

--- a/Frontend/bunfig.toml
+++ b/Frontend/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test-setup.ts"]

--- a/Frontend/docs/tests/test-spec-003.md
+++ b/Frontend/docs/tests/test-spec-003.md
@@ -1,0 +1,118 @@
+# テスト仕様書 003 — 2026-05-14 追加機能（アクセント・文字起こしモード・TermDetailPanel）
+
+作成日: 2026-05-14  
+テストランナー: Bun Test（`Frontend/bunfig.toml` の `preload` で happy-dom を登録）  
+作業ブランチ: `test/spec-2026-05-14-transcription-accent-termdetail`
+
+> **参照ドキュメント**: `Frontend/AGENTS.md`（テスト配置・`bun test`）、`AGENTS.md`（リポジトリ全体）
+
+---
+
+## 背景（本日の対象機能の整理）
+
+`git log` 上、2026-05-14 に `develop/v0` へマージされた主な変更は次のとおりです。
+
+| PR / 内容 | 概要 |
+|-----------|------|
+| #26 `feature/accent-color-theming` | アクセントテーマ、`accentStyles`、レイアウトの色味など |
+| #27 `fix/transcription-recording-stale-service` | `useTranscription` のモードと `getTranscriptionService()` の同期 |
+| #28 `fix/term-detail-panel-hooks-order` | `TermDetailPanel` の Rules of Hooks 違反修正 |
+
+本仕様書では、上記のうち **自動テストで固定しやすい範囲** に絞って単体・結合テストを追加する。
+
+---
+
+## 結果サマリー（本書作成・実行時点）
+
+| 項目 | 結果 |
+|------|------|
+| 総テスト数 | 68 |
+| 合格 | 68 |
+| 失敗 | 0 |
+| テストファイル数 | 17 |
+| 実行コマンド | `cd Frontend && bun test` |
+| 備考 | `package.json` に `"test": "bun test"` を追加 |
+
+---
+
+## テスト環境（結合テスト用）
+
+| 項目 | 内容 |
+|------|------|
+| DOM | `@happy-dom/global-registrator` を `Frontend/test-setup.ts` で preload 登録 |
+| React 結合 | `@testing-library/react` の `render` / `act`（`screen` はグローバル `document` 束縛の都合で未使用） |
+| 各テスト後 | `cleanup()` と `document.body.replaceChildren()` |
+
+---
+
+## 1. 単体 — `src/theme/__tests__/accentStyles.test.ts`（PR #26 関連）
+
+**目的**: テーマ色を CSS に落とす純関数の出力を固定し、リグレッションを防ぐ。
+
+| # | テストケース | 期待結果 | 結果 |
+|---|----------------|----------|------|
+| 1 | `accentRgba` | `rgba(r,g,b,a)` 形式 | ✅ |
+| 2 | `accentRgbSolid` | `rgb(r,g,b)` 形式 | ✅ |
+| 3 | `micStartButtonStyle` | 背景・文字色・ダーク/ライトで異なる boxShadow | ✅ |
+| 4 | `termChipStyle` | ダーク/ライトで背景アルファが異なる | ✅ |
+| 5 | `accentSliderStyle` | `accentColor` が `rgb(...)` | ✅ |
+
+---
+
+## 2. 単体 — `src/presentation/hooks/__tests__/transcriptionModeSync.test.ts`（PR #27）
+
+**目的**: グローバルな文字起こしモードとサービス実装の対応が一貫していることを検証する。
+
+| # | テストケース | 期待結果 | 結果 |
+|---|----------------|----------|------|
+| 1 | `fast` 時の `getTranscriptionService()` | `WebSpeechTranscriptionService` インスタンス | ✅ |
+| 2 | `setTranscriptionMode('accurate')` 後 | `LocalSttTranscriptionService` インスタンス | ✅ |
+| 3 | モード往復 | `fast` へ戻したとき同一シングルトン参照 | ✅ |
+| 4 | 同一モードへの `setTranscriptionMode` | 例外なく no-op | ✅ |
+
+---
+
+## 3. 結合 — `src/presentation/hooks/__tests__/useTranscriptionModeBroadcast.test.tsx`（PR #27）
+
+**目的**: `useSyncExternalStore` によるモード購読が、**同一ツリー内の複数フック利用者**に一斉に反映されることを検証する。
+
+| # | テストケース | 期待結果 | 結果 |
+|---|----------------|----------|------|
+| 1 | 2 つの `ModeLabel` を `render` 後、`setTranscriptionMode` を `act` 内で実行 | 両方の表示が `fast` → `accurate` → `fast` に追従 | ✅ |
+
+---
+
+## 4. 結合 — `src/app/components/__tests__/TermDetailPanel.test.tsx`（PR #28）
+
+**目的**: `term` の有無で早期 return しても **フック本数が変わらない** 修正が効いていることを、`null` ⇄ 用語の **同一ルート `rerender`** で検証する。
+
+| # | テストケース | 期待結果 | 結果 |
+|---|----------------|----------|------|
+| 1 | `term === null` | プレースホルダ文言が表示される | ✅ |
+| 2 | `term` あり | 見出し語・長文説明が表示される | ✅ |
+| 3 | `null → term → null` の `rerender` | エラーなく表示が切り替わる | ✅ |
+
+---
+
+## 自動テスト対象外（変更なし）
+
+- レイアウトエンジンの視覚的なアクセントグラデーション強度
+- 録音ボタン配色（紫／緑）の見た目
+- 実マイク・Web Speech / ローカル STT サーバーとの E2E
+
+上記は `bun run dev` による手動確認とする（`test-spec-002.md` の方針に準拠）。
+
+---
+
+## 手動確認チェックリスト（任意）
+
+- [ ] 設定で文字起こしモードを切替えたあと、操作ドックの録音が期待モードで動く
+- [ ] バブル／文字起こしから用語を開き、`TermDetailPanel` がエラーなく表示される
+- [ ] アクセント色変更後、チップ・スライダー等の色が追従する
+
+---
+
+## 気づき・注意点
+
+- `Frontend` 直下の `bunfig.toml` は **`cd Frontend` から `bun test` を実行したとき**に読み込まれる。リポジトリルートからテストする場合は `bun test --cwd Frontend` 等の運用を検討する。
+- `@testing-library/react` の `screen` は、happy-dom 登録タイミングによりグローバル `document` と不整合になることがあるため、本追加テストでは **`render()` の戻り値**でクエリする。

--- a/Frontend/docs/tests/test-spec-003.md
+++ b/Frontend/docs/tests/test-spec-003.md
@@ -17,6 +17,7 @@
 | #26 `feature/accent-color-theming` | アクセントテーマ、`accentStyles`、レイアウトの色味など |
 | #27 `fix/transcription-recording-stale-service` | `useTranscription` のモードと `getTranscriptionService()` の同期 |
 | #28 `fix/term-detail-panel-hooks-order` | `TermDetailPanel` の Rules of Hooks 違反修正 |
+| #29 `feature/ux-recording-and-window-controls` | 録音一時停止・操作ドックUI・ウィンドウピッカー等（本ブランチへ `develop/v0` 経由で取り込み後もテスト再実行で確認） |
 
 本仕様書では、上記のうち **自動テストで固定しやすい範囲** に絞って単体・結合テストを追加する。
 
@@ -32,6 +33,7 @@
 | テストファイル数 | 17 |
 | 実行コマンド | `cd Frontend && bun test` |
 | 備考 | `package.json` に `"test": "bun test"` を追加 |
+| 追記（`develop/v0` 取り込み後） | `origin/develop/v0`（PR #29 マージ済み）をマージした状態で `bun test` / `bun run build` 再実行 → いずれも成功 |
 
 ---
 

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "tsc -b && vite build",
+    "test": "bun test",
     "lint": "eslint .",
     "preview": "vite preview",
     "test:local-server": "node tests/local-server/transcriptReceiver.mjs",
@@ -64,7 +65,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@happy-dom/global-registrator": "^20.9.0",
     "@tailwindcss/vite": "^4.0.9",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.13.5",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
@@ -74,6 +77,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
+    "happy-dom": "^20.9.0",
     "tailwindcss": "^4.0.9",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",

--- a/Frontend/src/app/components/__tests__/TermDetailPanel.test.tsx
+++ b/Frontend/src/app/components/__tests__/TermDetailPanel.test.tsx
@@ -1,0 +1,64 @@
+/// <reference lib="dom" />
+import React from 'react'
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render } from '@testing-library/react'
+import { TermDetailPanel } from '../TermDetailPanel'
+import type { Term } from '../../data/terms'
+import { useContentFontScaleStore } from '../../../stores/contentFontScaleStore'
+
+const noop = () => {}
+
+const sampleTerm: Term = {
+  id: 'test-term-1',
+  word: 'RAG',
+  kana: 'ラグ',
+  shortDesc: '検索拡張生成',
+  longDesc: '検索と生成を組み合わせるアプローチの説明文です。',
+  category: 'AI/Data',
+  level: 2,
+  relatedTerms: ['ベクトル'],
+}
+
+describe('TermDetailPanel (PR #28: Hooks 順序)', () => {
+  beforeEach(() => {
+    useContentFontScaleStore.setState({ scale: 1 })
+  })
+
+  it('term が null のときプレースホルダーを表示する', () => {
+    const view = render(
+      <TermDetailPanel
+        term={null}
+        onClose={noop}
+        onRelatedTermClick={noop}
+        darkMode
+      />,
+    )
+    expect(view.getByText(/用語をクリックすると/)).toBeTruthy()
+  })
+
+  it('term があるとき見出しに単語を表示する', () => {
+    const view = render(
+      <TermDetailPanel
+        term={sampleTerm}
+        onClose={noop}
+        onRelatedTermClick={noop}
+        darkMode
+      />,
+    )
+    expect(view.getByText('RAG')).toBeTruthy()
+    expect(view.getByText(/検索と生成を組み合わせる/)).toBeTruthy()
+  })
+
+  it('同一ルートで null → term に切り替えてもフック順エラーにならない', () => {
+    const { rerender, getByText } = render(
+      <TermDetailPanel term={null} onClose={noop} onRelatedTermClick={noop} darkMode />,
+    )
+    expect(getByText(/用語をクリックすると/)).toBeTruthy()
+
+    rerender(<TermDetailPanel term={sampleTerm} onClose={noop} onRelatedTermClick={noop} darkMode />)
+    expect(getByText('RAG')).toBeTruthy()
+
+    rerender(<TermDetailPanel term={null} onClose={noop} onRelatedTermClick={noop} darkMode />)
+    expect(getByText(/用語をクリックすると/)).toBeTruthy()
+  })
+})

--- a/Frontend/src/presentation/hooks/__tests__/transcriptionModeSync.test.ts
+++ b/Frontend/src/presentation/hooks/__tests__/transcriptionModeSync.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import {
+  getTranscriptionMode,
+  getTranscriptionService,
+  setTranscriptionMode,
+} from '../useTranscription'
+import { WebSpeechTranscriptionService } from '../../../infrastructure/speech/WebSpeechTranscriptionService'
+import { LocalSttTranscriptionService } from '../../../infrastructure/speech/LocalSttTranscriptionService'
+import { useTranscriptStore } from '../../../stores/transcriptStore'
+
+describe('transcription mode / service 同期 (PR #27)', () => {
+  beforeEach(() => {
+    setTranscriptionMode('fast')
+    useTranscriptStore.setState({ transcript: '', status: 'idle' })
+  })
+
+  it('getTranscriptionService は fast で WebSpeech 実装を返す', () => {
+    const svc = getTranscriptionService()
+    expect(svc).toBeInstanceOf(WebSpeechTranscriptionService)
+    expect(getTranscriptionMode()).toBe('fast')
+  })
+
+  it('setTranscriptionMode で accurate に切替えると LocalStt が返る', () => {
+    setTranscriptionMode('accurate')
+    expect(getTranscriptionMode()).toBe('accurate')
+    expect(getTranscriptionService()).toBeInstanceOf(LocalSttTranscriptionService)
+  })
+
+  it('往復で同じインスタンスに戻る（シングルトン）', () => {
+    const fastA = getTranscriptionService()
+    setTranscriptionMode('accurate')
+    setTranscriptionMode('fast')
+    const fastB = getTranscriptionService()
+    expect(fastB).toBe(fastA)
+  })
+
+  it('同一モードへの set は no-op で例外にならない', () => {
+    setTranscriptionMode('fast')
+    setTranscriptionMode('fast')
+    expect(getTranscriptionMode()).toBe('fast')
+  })
+})

--- a/Frontend/src/presentation/hooks/__tests__/useTranscriptionModeBroadcast.test.tsx
+++ b/Frontend/src/presentation/hooks/__tests__/useTranscriptionModeBroadcast.test.tsx
@@ -1,0 +1,41 @@
+/// <reference lib="dom" />
+import React from 'react'
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, act } from '@testing-library/react'
+import { useTranscription, setTranscriptionMode } from '../useTranscription'
+import { useTranscriptStore } from '../../../stores/transcriptStore'
+
+function ModeLabel() {
+  const { mode } = useTranscription()
+  return <span data-testid="mode-label">{mode}</span>
+}
+
+describe('useTranscription 結合: モード購読の共有 (PR #27)', () => {
+  beforeEach(() => {
+    setTranscriptionMode('fast')
+    useTranscriptStore.setState({ transcript: '', status: 'idle' })
+  })
+
+  it('同一ツリー内の複数コンポーネントが setTranscriptionMode に追従する', () => {
+    const view = render(
+      <div>
+        <ModeLabel />
+        <ModeLabel />
+      </div>,
+    )
+    expect(view.getAllByTestId('mode-label').every((el) => el.textContent === 'fast')).toBe(true)
+
+    act(() => {
+      setTranscriptionMode('accurate')
+    })
+
+    const labels = view.getAllByTestId('mode-label')
+    expect(labels).toHaveLength(2)
+    expect(labels.every((el) => el.textContent === 'accurate')).toBe(true)
+
+    act(() => {
+      setTranscriptionMode('fast')
+    })
+    expect(labels.every((el) => el.textContent === 'fast')).toBe(true)
+  })
+})

--- a/Frontend/src/theme/__tests__/accentStyles.test.ts
+++ b/Frontend/src/theme/__tests__/accentStyles.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'bun:test'
+import { accentRgba, accentRgbSolid, micStartButtonStyle, termChipStyle, accentSliderStyle } from '../accentStyles'
+
+describe('accentStyles', () => {
+  const rgb = '99,102,241'
+
+  it('accentRgba は rgba 文字列を返す', () => {
+    expect(accentRgba(rgb, 0.5)).toBe('rgba(99,102,241,0.5)')
+  })
+
+  it('accentRgbSolid は rgb 文字列を返す', () => {
+    expect(accentRgbSolid(rgb)).toBe('rgb(99,102,241)')
+  })
+
+  it('micStartButtonStyle は背景・文字色・シャドウを含む', () => {
+    const dk = micStartButtonStyle(rgb, true)
+    expect(dk.backgroundColor).toBe('rgb(99,102,241)')
+    expect(dk.color).toBe('#fff')
+    expect(dk.boxShadow).toContain('rgba(99,102,241,0.42)')
+    const lt = micStartButtonStyle(rgb, false)
+    expect(lt.boxShadow).toContain('rgba(99,102,241,0.28)')
+  })
+
+  it('termChipStyle はダーク/ライトで境界と背景が変わる', () => {
+    const dark = termChipStyle(true, rgb)
+    expect(dark.borderStyle).toBe('solid')
+    expect(dark.backgroundColor).toContain('0.26')
+    const light = termChipStyle(false, rgb)
+    expect(light.backgroundColor).toContain('0.12')
+  })
+
+  it('accentSliderStyle は accentColor を返す', () => {
+    expect(accentSliderStyle(rgb)).toEqual({ accentColor: 'rgb(99,102,241)' })
+  })
+})

--- a/Frontend/test-setup.ts
+++ b/Frontend/test-setup.ts
@@ -1,0 +1,10 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { afterEach } from 'bun:test'
+import { cleanup } from '@testing-library/react'
+
+GlobalRegistrator.register()
+
+afterEach(() => {
+  cleanup()
+  document.body.replaceChildren()
+})


### PR DESCRIPTION
## 概要
PR #26〜#28 向けの単体・結合テストと `Frontend/docs/tests/test-spec-003.md` を追加し、`bun test` / happy-dom / Testing Library の土台を整備しました。

## develop/v0 の取り込み
`origin/develop/v0`（PR #29 マージ済み）を **マージで取り込み**済みです。コンフリクトなし。

## 検証
- `cd Frontend && bun test` → 68 件すべて成功
- `cd Frontend && bun run build` → 成功

## 変更の要点
- `package.json`: `"test": "bun test"`、devDependencies（happy-dom 等）
- `bunfig.toml` + `test-setup.ts`: DOM プリロードと RTL cleanup
- 新規テスト: `accentStyles`、`transcriptionModeSync`、`useTranscriptionModeBroadcast`、`TermDetailPanel`

Made with [Cursor](https://cursor.com)