### PR TITLE
操作ウィンドウのレスポンシブ配置と最小サイズ制御を改善

### DIFF
--- a/Frontend/docs/tests/test-spec-004.md
+++ b/Frontend/docs/tests/test-spec-004.md
@@ -1,0 +1,148 @@
+# test-spec-004: 操作ウィンドウ UX・最小サイズ
+
+## 日付
+
+2026-05-15
+
+## 対象ファイル
+
+- `Frontend/src/presentation/windows/SystemControlWindow/index.tsx`
+- `Frontend/src/presentation/components/PhaseTransitionButton.tsx`
+- `Frontend/src/presentation/constants/systemControlWindow.ts`
+- `Frontend/src/presentation/layout/LayoutEngine.tsx`
+- `Frontend/test-setup.ts`
+- `Frontend/bunfig.toml`
+
+## 対象ブランチ
+
+`feature/system-control-reset-button-size`
+
+## テストの目的
+
+このブランチで変更した操作ウィンドウについて、以下を確認する。
+
+- 録音／発表終了／リセットの 3 ボタンが、横長・縦長・中間比率で破綻なく配置されること
+- 録音と発表終了を同格の主操作、リセットを低優先の副操作として認識できること
+- 最小幅・最小高さを下回るリサイズで、ボタンが画面外に移動しないこと
+- 操作ウィンドウの高さ下限が CSS だけでなく、ドラッグ時の分割比率にも反映されること
+- React Testing Library を使う `.tsx` テストで happy-dom の DOM 環境が正しく登録されること
+
+## 参照したルール・設計文書
+
+- ルート `AGENTS.md`
+- `Frontend/AGENTS.md`
+- `Frontend/docs/orders/order-001.md`
+- `Frontend/docs/ADRs/adr-001.md` 〜 `adr-008.md`
+
+## テスト項目
+
+| # | テストケース | 種別 | 期待結果 |
+|---|---|---|---|
+| 1 | `bun run build` | 自動 | TypeScript build と Vite build が成功する |
+| 2 | `bun test` | 自動 | 既存の単体・結合テスト 68 件がすべて成功する |
+| 3 | 横長の操作ウィンドウ | 手動 | 録音／発表終了／リセットが横一列に並び、見切れない |
+| 4 | 縦長の操作ウィンドウ | 手動 | 3 ボタンが縦一列に並び、主操作と副操作の優先度が分かる |
+| 5 | 中間比率の操作ウィンドウ | 手動 | 録音／発表終了が主操作、リセットが右下寄りの副操作として表示される |
+| 6 | 最小幅方向へのリサイズ | 手動 | 操作ウィンドウが最小幅以下に潰れず、ボタンが画面外に移動しない |
+| 7 | 最小高さ方向へのリサイズ | 手動 | 操作ウィンドウが最小高さ以下に潰れず、ボタンが画面外に移動しない |
+| 8 | 最小サイズ以上でのリサイズ | 手動 | 最大幅・最大比率による固定化がなく、従来どおり自由にリサイズできる |
+| 9 | リセット確認ダイアログ | 手動 | リセット押下で確認が表示され、キャンセル時は状態が維持される |
+| 10 | レイアウトエンジン回帰 | 手動 | 操作ウィンドウ以外のドラッグ移動・リサイズが破綻しない |
+
+## 実行結果
+
+### 実行コマンド
+
+```bash
+cd Frontend
+bun run build
+bun test
+```
+
+| コマンド | 結果 | メモ |
+|----------|------|------|
+| `bun run build` | 合格 | TypeScript build と Vite build が成功 |
+| `bun test` | 合格 | 68 件成功、0 件失敗 |
+
+`bun test` の内訳:
+
+| 項目 | 件数 |
+|------|------|
+| 総テスト数 | 68 |
+| 成功 | 68 |
+| 失敗 | 0 |
+| expect 呼び出し | 115 |
+| テストファイル数 | 17 |
+
+### 通過した主な範囲
+
+- `termStore`
+- `phaseStore`
+- `transcriptStore`
+- `accentStyles`
+- `TermDetailPanel`
+- `LayoutUseCase`
+- `BubbleImportanceUseCase`
+- `VectorSimilarityStrategy`
+- `FrequencyStrategy`
+- `LayoutRepository`
+- `Term` / `Layout` entity
+- `importanceRanking`
+- `oppositeThemeColor`
+- `transcriptionModeSync`
+- `useTranscriptionModeBroadcast`
+- `mockImportantTerms`
+
+## 気づき・注意点
+
+- React Testing Library を使う `.tsx` テストは DOM 環境を必要とする。
+- このリポジトリでは `Frontend/bunfig.toml` の `[test].preload` から `Frontend/test-setup.ts` を読み込み、happy-dom を登録する。
+- テストは必ず `Frontend/` をカレントディレクトリにして実行する。
+
+リポジトリルートから `bun test` を直接実行すると `Frontend/bunfig.toml` が読まれず、`document is not defined` が発生する可能性がある。特に影響するテストは以下。
+
+- `src/app/components/__tests__/TermDetailPanel.test.tsx`
+- `src/presentation/hooks/__tests__/useTranscriptionModeBroadcast.test.tsx`
+
+## 手動テストチェックリスト
+
+`bun run dev` でプレゼン画面を開き、Chrome 系ブラウザで確認する。
+
+### 操作ウィンドウのリサイズ
+
+- [ ] 操作ウィンドウを横長にしたとき、3 ボタンが横一列に並ぶ
+- [ ] 操作ウィンドウを縦長にしたとき、3 ボタンが縦一列に並ぶ
+- [ ] 中間比率では、録音／発表終了が主操作として見え、リセットが右下寄りの副操作として見える
+- [ ] 極小に近いサイズでも、ボタン文言やアイコンが画面外に移動しない
+- [ ] 最小幅を下回る方向へドラッグしても、操作ウィンドウがそれ以上潰れない
+- [ ] 最小高さを下回る方向へドラッグしても、操作ウィンドウがそれ以上潰れない
+- [ ] 最小サイズ以上では、従来どおり自由にリサイズできる
+
+### ボタンの UX
+
+- [ ] 録音ボタンと発表終了ボタンが同程度の重要度に見える
+- [ ] リセットボタンが他 2 つより少し小さく、低優先の操作として見える
+- [ ] 録音開始／一時停止／再開の状態変化でボタンが見切れない
+- [ ] リセット押下時に確認ダイアログが表示される
+- [ ] リセット確認ダイアログでキャンセルすると状態が維持される
+
+### レイアウトエンジン回帰
+
+- [ ] 操作ウィンドウ以外のウィンドウをドラッグ移動できる
+- [ ] 操作ウィンドウを含むレイアウトでも、他ウィンドウのリサイズが破綻しない
+- [ ] 操作ウィンドウの最大幅・最大比率による固定化が起きていない
+- [ ] 発表中フェーズと発表後フェーズの両方で操作ウィンドウが表示される
+
+## 自動テスト対象外
+
+- 実マイク入力と Web Speech API の E2E
+- ローカル STT サーバーとの接続確認
+- 操作ウィンドウの細かな視覚バランス
+- ユーザー環境ごとのブラウザリサイズ挙動
+
+上記は `bun run dev` での手動確認を正とする。
+
+## 判定
+
+自動テストは合格。
+操作ウィンドウの視覚的な最終判定は、セクション 4 の手動チェックリストで確認する。

--- a/Frontend/src/presentation/components/PhaseTransitionButton.tsx
+++ b/Frontend/src/presentation/components/PhaseTransitionButton.tsx
@@ -34,11 +34,11 @@ export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compac
   if (compact) {
     const outlineCls = isDuring
       ? dk
-        ? 'border-rose-500/55 bg-gradient-to-b from-rose-500/16 to-rose-600/8 text-rose-300 hover:from-rose-500/26 hover:to-rose-600/16 shadow-[inset_0_1px_0_rgba(251,113,133,0.14)] focus-visible:ring-rose-400/60'
-        : 'border-rose-300 bg-gradient-to-b from-white to-rose-50 text-rose-600 hover:from-rose-50 hover:to-rose-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_1px_3px_rgba(200,50,50,0.1)] focus-visible:ring-rose-400/60'
+        ? 'border-rose-400/65 bg-gradient-to-b from-rose-400 to-rose-600 text-white shadow-[0_2px_14px_rgba(244,63,94,0.42),inset_0_1px_0_rgba(255,255,255,0.2)] hover:brightness-[1.08] focus-visible:ring-rose-400/70'
+        : 'border-rose-500/70 bg-gradient-to-b from-rose-400 to-rose-600 text-white shadow-[0_2px_12px_rgba(244,63,94,0.26),inset_0_1px_0_rgba(255,255,255,0.24)] hover:brightness-[1.05] focus-visible:ring-rose-400/70'
       : dk
-        ? 'border-emerald-500/55 bg-gradient-to-b from-emerald-500/16 to-emerald-600/8 text-emerald-300 hover:from-emerald-500/26 hover:to-emerald-600/16 shadow-[inset_0_1px_0_rgba(52,211,153,0.14)] focus-visible:ring-emerald-400/60'
-        : 'border-emerald-300 bg-gradient-to-b from-white to-emerald-50 text-emerald-700 hover:from-emerald-50 hover:to-emerald-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_1px_3px_rgba(0,140,80,0.1)] focus-visible:ring-emerald-400/60'
+        ? 'border-sky-400/65 bg-gradient-to-b from-sky-400 to-sky-600 text-white shadow-[0_2px_14px_rgba(14,165,233,0.38),inset_0_1px_0_rgba(255,255,255,0.2)] hover:brightness-[1.08] focus-visible:ring-sky-400/70'
+        : 'border-sky-500/70 bg-gradient-to-b from-sky-400 to-sky-600 text-white shadow-[0_2px_12px_rgba(14,165,233,0.24),inset_0_1px_0_rgba(255,255,255,0.24)] hover:brightness-[1.05] focus-visible:ring-sky-400/70'
 
     return (
       <button

--- a/Frontend/src/presentation/components/PhaseTransitionButton.tsx
+++ b/Frontend/src/presentation/components/PhaseTransitionButton.tsx
@@ -7,9 +7,11 @@ interface Props {
   darkMode?: boolean
   /** 操作ドック内: 録音ボタンの下に配置する従属ボタン */
   compact?: boolean
+  /** compact 時に追加で付与するクラス */
+  compactClassName?: string
 }
 
-export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compact = false }) => {
+export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compact = false, compactClassName = '' }) => {
   const currentPhaseId = usePhaseStore(s => s.currentPhaseId)
   const transitionTo = usePhaseStore(s => s.transitionTo)
   const clearBubbles = useBubbleStore(s => s.clearBubbles)
@@ -32,11 +34,11 @@ export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compac
   if (compact) {
     const outlineCls = isDuring
       ? dk
-        ? 'border-rose-500/50 text-rose-400 hover:bg-rose-500/15 focus-visible:ring-rose-400/60'
-        : 'border-rose-400 text-rose-600 bg-rose-50 hover:bg-rose-100 focus-visible:ring-rose-400/60'
+        ? 'border-rose-500/55 bg-gradient-to-b from-rose-500/16 to-rose-600/8 text-rose-300 hover:from-rose-500/26 hover:to-rose-600/16 shadow-[inset_0_1px_0_rgba(251,113,133,0.14)] focus-visible:ring-rose-400/60'
+        : 'border-rose-300 bg-gradient-to-b from-white to-rose-50 text-rose-600 hover:from-rose-50 hover:to-rose-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_1px_3px_rgba(200,50,50,0.1)] focus-visible:ring-rose-400/60'
       : dk
-        ? 'border-emerald-500/50 text-emerald-400 hover:bg-emerald-500/15 focus-visible:ring-emerald-400/60'
-        : 'border-emerald-400 text-emerald-700 bg-emerald-50 hover:bg-emerald-100 focus-visible:ring-emerald-400/60'
+        ? 'border-emerald-500/55 bg-gradient-to-b from-emerald-500/16 to-emerald-600/8 text-emerald-300 hover:from-emerald-500/26 hover:to-emerald-600/16 shadow-[inset_0_1px_0_rgba(52,211,153,0.14)] focus-visible:ring-emerald-400/60'
+        : 'border-emerald-300 bg-gradient-to-b from-white to-emerald-50 text-emerald-700 hover:from-emerald-50 hover:to-emerald-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_1px_3px_rgba(0,140,80,0.1)] focus-visible:ring-emerald-400/60'
 
     return (
       <button
@@ -44,7 +46,7 @@ export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compac
         onClick={handleClick}
         title={isDuring ? '発表を終了する' : '発表中に戻る'}
         aria-label={isDuring ? '発表を終了する' : '発表中に戻る'}
-        className={`inline-flex w-full items-center justify-center gap-1.5 rounded-lg border px-2.5 py-2 text-xs font-bold transition-colors active:scale-[0.98] ${outlineCls} ${focusRing} ${ringOffset}`}
+        className={`inline-flex w-full items-center justify-center gap-1.5 rounded-full border px-2.5 py-2 text-xs font-bold transition-colors active:scale-[0.98] ${outlineCls} ${focusRing} ${ringOffset} ${compactClassName}`}
       >
         {isDuring ? (
           <>
@@ -75,7 +77,7 @@ export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compac
       onClick={handleClick}
       title={isDuring ? '発表を終了する' : '発表中に戻る'}
       aria-label={isDuring ? '発表を終了する' : '発表中に戻る'}
-      className={`inline-flex h-[3.25rem] w-full shrink-0 items-center justify-center gap-2.5 rounded-xl px-6 text-sm font-bold leading-none shadow-lg transition-transform active:scale-[0.98] hover:scale-[1.01] ${surface} ${focusRing} ${ringOffset}`}
+      className={`inline-flex h-[3.25rem] w-full shrink-0 items-center justify-center gap-2.5 rounded-full px-6 text-sm font-bold leading-none shadow-lg transition-transform active:scale-[0.98] hover:scale-[1.01] ${surface} ${focusRing} ${ringOffset}`}
     >
       {isDuring ? (
         <>

--- a/Frontend/src/presentation/constants/systemControlWindow.ts
+++ b/Frontend/src/presentation/constants/systemControlWindow.ts
@@ -5,5 +5,14 @@ export const SYSTEM_CONTROL_WINDOW_ID = 'systemControl' as const
  * 操作ウィンドウがレイアウト上で確保する最小サイズ（px）。
  * これより狭い／低いと主要ボタンが潰れるため、分割ペインとウィンドウ本体の双方で下限を張る。
  */
-export const SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX = 156
-export const SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX = 196
+export const SYSTEM_CONTROL_CONTENT_MIN_WIDTH_PX = 168
+export const SYSTEM_CONTROL_CONTENT_MIN_HEIGHT_PX = 156
+
+/**
+ * レイアウト上の最小高はウィンドウヘッダーを含む。
+ * SystemControlWindow 本体はヘッダー下に描画されるため、同じ値を使うと下部ボタンが見切れる。
+ */
+export const SYSTEM_CONTROL_DOCK_HEADER_RESERVE_PX = 36
+export const SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX = SYSTEM_CONTROL_CONTENT_MIN_WIDTH_PX
+export const SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX =
+  SYSTEM_CONTROL_CONTENT_MIN_HEIGHT_PX + SYSTEM_CONTROL_DOCK_HEADER_RESERVE_PX

--- a/Frontend/src/presentation/layout/LayoutEngine.tsx
+++ b/Frontend/src/presentation/layout/LayoutEngine.tsx
@@ -5,6 +5,8 @@ import { movePanel, updateRatio } from './layoutUtils'
 import { getWindowDefinition } from '../windows/registry'
 import {
   SYSTEM_CONTROL_WINDOW_ID,
+  SYSTEM_CONTROL_CONTENT_MIN_HEIGHT_PX,
+  SYSTEM_CONTROL_CONTENT_MIN_WIDTH_PX,
   SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
   SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
 } from '../constants/systemControlWindow'
@@ -66,7 +68,30 @@ interface ResizeState {
   startRatio: number
   direction: 'h' | 'v'
   containerSize: number
+  minRatio: number
+  maxRatio: number
 }
+
+const clamp = (min: number, max: number, value: number): number =>
+  Math.max(min, Math.min(max, value))
+
+const containsSystemControlWindow = (node: LayoutNode): boolean => {
+  if (node.type === 'leaf') return node.windowId === SYSTEM_CONTROL_WINDOW_ID
+  return containsSystemControlWindow(node.a) || containsSystemControlWindow(node.b)
+}
+
+const getSystemControlMinSize = (node: LayoutNode, direction: 'h' | 'v'): number => {
+  if (!containsSystemControlWindow(node)) return 0
+  return direction === 'h' ? SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX : SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX
+}
+
+const systemControlMinStyle = (node: LayoutNode): React.CSSProperties =>
+  containsSystemControlWindow(node)
+    ? {
+        minWidth: SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
+        minHeight: SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
+      }
+    : { minWidth: 0, minHeight: 0 }
 
 export interface LayoutEngineProps {
   layout: LayoutNode
@@ -98,7 +123,7 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
     const onMove = (e: MouseEvent) => {
       const delta = resizing.direction === 'h' ? e.clientX - resizing.startPos : e.clientY - resizing.startPos
       const newRatio = resizing.startRatio + delta / resizing.containerSize
-      onLayoutChange(updateRatio(layoutRef.current, resizing.splitId, newRatio))
+      onLayoutChange(updateRatio(layoutRef.current, resizing.splitId, clamp(resizing.minRatio, resizing.maxRatio, newRatio)))
     }
     const onUp = () => setResizing(null)
     window.addEventListener('mousemove', onMove)
@@ -162,7 +187,15 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
               </button>
             )}
           </div>
-          <div style={{ flex: 1, minHeight: 0, position: 'relative', overflow: 'hidden' }}>
+          <div
+            style={{
+              flex: 1,
+              minWidth: isSystemControl ? SYSTEM_CONTROL_CONTENT_MIN_WIDTH_PX : 0,
+              minHeight: isSystemControl ? SYSTEM_CONTROL_CONTENT_MIN_HEIGHT_PX : 0,
+              position: 'relative',
+              overflow: 'hidden',
+            }}
+          >
             <div className="relative z-0 h-full min-h-0 overflow-hidden">
               {WindowComponent
                 ? <WindowComponent windowId={node.windowId} darkMode={darkMode} />
@@ -200,14 +233,14 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
     }
 
     const isH = node.direction === 'h'
-    const isSystemControlDockPane = isH && node.a.type === 'leaf' && node.a.windowId === SYSTEM_CONTROL_WINDOW_ID
+    const aMinStyle = systemControlMinStyle(node.a)
+    const bMinStyle = systemControlMinStyle(node.b)
     const aStyle: React.CSSProperties = isH
       ? {
           width: `${node.ratio * 100}%`,
           flexShrink: 0,
           flexGrow: 0,
-          minWidth: isSystemControlDockPane ? SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX : 0,
-          minHeight: isSystemControlDockPane ? SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX : 0,
+          ...aMinStyle,
           overflow: 'hidden',
           display: 'flex',
         }
@@ -215,11 +248,16 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
           height: `${node.ratio * 100}%`,
           flexShrink: 0,
           flexGrow: 0,
-          minHeight: 0,
+          ...aMinStyle,
           overflow: 'hidden',
           display: 'flex',
         }
-    const bStyle: React.CSSProperties = { flex: 1, minWidth: 0, minHeight: 0, overflow: 'hidden', display: 'flex' }
+    const bStyle: React.CSSProperties = {
+      flex: 1,
+      ...bMinStyle,
+      overflow: 'hidden',
+      display: 'flex',
+    }
 
     return (
       <div key={node.id} style={{ display: 'flex', flexDirection: isH ? 'row' : 'column', width: '100%', height: '100%', minWidth: 0, minHeight: 0 }}>
@@ -232,12 +270,19 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
             e.preventDefault()
             const parent = (e.currentTarget as HTMLElement).parentElement!
             const rect = parent.getBoundingClientRect()
+            const containerSize = (isH ? rect.width : rect.height) - 4
+            const minA = getSystemControlMinSize(node.a, node.direction)
+            const minB = getSystemControlMinSize(node.b, node.direction)
+            const minRatio = containerSize > 0 ? minA / containerSize : 0.1
+            const maxRatio = containerSize > 0 ? 1 - minB / containerSize : 0.9
             setResizing({
               splitId: node.id,
               startPos: isH ? e.clientX : e.clientY,
               startRatio: node.ratio,
               direction: node.direction,
-              containerSize: (isH ? rect.width : rect.height) - 4,
+              containerSize,
+              minRatio: Math.min(0.9, minRatio),
+              maxRatio: Math.max(0.1, maxRatio),
             })
           }}
         />
@@ -247,8 +292,10 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dragging, dropInfo, darkMode, accentRgb, borderStyle, headerBg, dotColor, panelGlow, calcZone, onLayoutChange, onClose])
 
+  const rootMinStyle = systemControlMinStyle(layout)
+
   return (
-    <div style={{ width: '100%', height: '100%', overflow: 'hidden' }}>
+    <div style={{ width: '100%', height: '100%', overflow: 'hidden', ...rootMinStyle }}>
       {renderNode(layout)}
     </div>
   )

--- a/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
+++ b/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
@@ -7,8 +7,8 @@ import { usePresentationShell } from '../../context/PresentationShellContext'
 import { useTranscription } from '../../hooks/useTranscription'
 import type { WindowProps } from '../IWindowDefinition'
 import {
-  SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
-  SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
+  SYSTEM_CONTROL_CONTENT_MIN_HEIGHT_PX,
+  SYSTEM_CONTROL_CONTENT_MIN_WIDTH_PX,
 } from '../../constants/systemControlWindow'
 
 const focusRing =
@@ -25,7 +25,7 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
   const [resetOpen, setResetOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const [layoutMode, setLayoutMode] = useState<ControlsLayoutMode>('tall')
-  const [viewportSize, setViewportSize] = useState({ width: SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX, height: SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX })
+  const [viewportSize, setViewportSize] = useState({ width: SYSTEM_CONTROL_CONTENT_MIN_WIDTH_PX, height: SYSTEM_CONTROL_CONTENT_MIN_HEIGHT_PX })
 
   const { isListening, isPaused, startListening, pauseListening } = useTranscription()
 
@@ -41,8 +41,8 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
 
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0]
-      const width = entry?.contentRect?.width ?? SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX
-      const height = entry?.contentRect?.height ?? SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX
+      const width = entry?.contentRect?.width ?? SYSTEM_CONTROL_CONTENT_MIN_WIDTH_PX
+      const height = entry?.contentRect?.height ?? SYSTEM_CONTROL_CONTENT_MIN_HEIGHT_PX
       setViewportSize({ width, height })
 
       const ratio = width / Math.max(height, 1)
@@ -132,8 +132,8 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
     <div
       ref={rootRef}
       style={{
-        minWidth: SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
-        minHeight: SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
+        minWidth: SYSTEM_CONTROL_CONTENT_MIN_WIDTH_PX,
+        minHeight: SYSTEM_CONTROL_CONTENT_MIN_HEIGHT_PX,
       }}
       className={`box-border flex h-full min-h-0 flex-col gap-2 overflow-y-auto p-2.5 ${
         dk ? 'bg-[#0d0e1a] text-slate-200' : 'bg-white text-slate-800'

--- a/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
+++ b/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { Mic, Pause, Play, RotateCcw, AlertTriangle } from 'lucide-react'
 import * as AlertDialog from '@radix-ui/react-alert-dialog'
@@ -14,21 +14,69 @@ import {
 const focusRing =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2'
 
+type ControlsLayoutMode = 'row' | 'column' | 'mid'
+
 export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const { onResetAll } = usePresentationShell()
   const dk = darkMode
   const [resetOpen, setResetOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const [layoutMode, setLayoutMode] = useState<ControlsLayoutMode>('column')
+  const [viewportSize, setViewportSize] = useState({ width: SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX, height: SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX })
 
   const { isListening, isPaused, startListening, pauseListening } = useTranscription()
 
   const ringOffsetCls = dk ? 'focus-visible:ring-offset-[#0d0e1a]' : 'focus-visible:ring-offset-white'
-  const divider = dk ? 'bg-slate-700/40' : 'bg-slate-200'
 
   const primaryBtnBase =
-    'relative flex h-12 min-h-12 w-full flex-row items-center justify-center gap-2 rounded-lg text-xs font-bold shadow-md transition-transform active:scale-[0.98]'
+    'relative flex h-full w-full min-w-0 flex-row items-center justify-center gap-2 rounded-full px-2.5 text-xs font-bold transition-transform active:scale-[0.98]'
+  const resetBtnBase = 'flex h-full w-full min-w-0 flex-row items-center justify-center gap-1.5 rounded-full border px-3 text-[11px] font-bold transition-colors'
+
+  useEffect(() => {
+    const el = rootRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      const width = entry?.contentRect?.width ?? SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX
+      const height = entry?.contentRect?.height ?? SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX
+      setViewportSize({ width, height })
+
+      const ratio = width / Math.max(height, 1)
+      if (ratio >= 1.34) setLayoutMode('row')
+      else if (ratio <= 0.78) setLayoutMode('column')
+      else setLayoutMode('mid')
+    })
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  const controlsLayoutClass = useMemo(() => {
+    if (layoutMode === 'row') return 'grid grid-cols-3 items-stretch gap-2'
+    if (layoutMode === 'column') return 'grid grid-cols-1 items-stretch gap-2'
+    return 'grid grid-cols-2 items-stretch gap-2'
+  }, [layoutMode])
+
+  const baseControlSize = useMemo(() => {
+    const { width, height } = viewportSize
+    if (layoutMode === 'row') {
+      return Math.max(54, Math.min(92, Math.floor((width - 32) / 3)))
+    }
+    if (layoutMode === 'column') {
+      return Math.max(54, Math.min(92, Math.floor((height - 52) / 3)))
+    }
+    const fromWidth = Math.floor((width - 24) / 2)
+    const fromHeight = Math.floor((height - 56) / 2)
+    return Math.max(52, Math.min(88, Math.min(fromWidth, fromHeight)))
+  }, [layoutMode, viewportSize])
+
+  const primaryTileStyle = { minHeight: baseControlSize, height: baseControlSize }
+  const resetTileStyle = { minHeight: Math.round(baseControlSize * 0.88), height: Math.round(baseControlSize * 0.88) }
 
   return (
     <div
+      ref={rootRef}
       style={{
         minWidth: SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX,
         minHeight: SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX,
@@ -37,126 +85,132 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
         dk ? 'bg-[#0d0e1a] text-slate-200' : 'bg-white text-slate-800'
       }`}
     >
-      {/* 録音コントロール（最優先） */}
-      <section aria-label="録音コントロール" className="flex flex-col gap-1.5">
-        <AnimatePresence mode="wait">
-          {isListening ? (
-            <motion.button
-              key="pause"
-              onClick={pauseListening}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.12 }}
-              whileTap={{ scale: 0.98 }}
-              className={`${primaryBtnBase} bg-amber-500 text-white shadow-amber-900/30 hover:bg-amber-400 ${focusRing} focus-visible:ring-amber-400/60 ${ringOffsetCls}`}
-              title="録音を一時停止"
-            >
-              <span className="pointer-events-none absolute inset-0 animate-ping rounded-lg bg-amber-400 opacity-15" />
-              <Pause size={16} fill="currentColor" className="shrink-0" />
-              <span className="min-w-0 truncate">一時停止</span>
-            </motion.button>
-          ) : isPaused ? (
-            <motion.button
-              key="resume"
-              onClick={startListening}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.12 }}
-              whileTap={{ scale: 0.98 }}
-              className={`${primaryBtnBase} bg-emerald-600 text-white shadow-emerald-900/30 hover:bg-emerald-500 ${focusRing} focus-visible:ring-emerald-400/60 ${ringOffsetCls}`}
-              title="録音を再開"
-            >
-              <Play size={16} fill="currentColor" className="shrink-0" />
-              <span className="min-w-0 truncate">再開</span>
-            </motion.button>
-          ) : (
-            <motion.button
-              key="start"
-              onClick={startListening}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.12 }}
-              whileTap={{ scale: 0.98 }}
-              className={`${primaryBtnBase} bg-emerald-500 text-white shadow-emerald-900/30 hover:bg-emerald-400 ${focusRing} focus-visible:ring-emerald-400/60 ${ringOffsetCls}`}
-              title="録音開始"
-            >
-              <Mic size={16} strokeWidth={2.25} className="shrink-0" />
-              <span className="min-w-0 truncate">録音</span>
-            </motion.button>
-          )}
-        </AnimatePresence>
+      <section aria-label="操作コントロール" className={controlsLayoutClass}>
+        <div style={primaryTileStyle}>
+          <AnimatePresence mode="wait">
+            {isListening ? (
+              <motion.button
+                key="pause"
+                onClick={pauseListening}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.12 }}
+                whileTap={{ scale: 0.98 }}
+                className={`${primaryBtnBase} bg-gradient-to-b from-amber-400 to-amber-600 text-white shadow-[0_2px_14px_rgba(245,158,11,0.45),inset_0_1px_0_rgba(255,255,255,0.2)] hover:brightness-[1.08] ${focusRing} focus-visible:ring-amber-400/70 ${ringOffsetCls}`}
+                title="録音を一時停止"
+              >
+                <span className="pointer-events-none absolute inset-0 animate-ping rounded-full bg-amber-300 opacity-10" />
+                <Pause size={16} fill="currentColor" className="shrink-0" />
+                <span className="min-w-0 truncate">一時停止</span>
+              </motion.button>
+            ) : isPaused ? (
+              <motion.button
+                key="resume"
+                onClick={startListening}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.12 }}
+                whileTap={{ scale: 0.98 }}
+                className={`${primaryBtnBase} bg-gradient-to-b from-emerald-400 to-emerald-600 text-white shadow-[0_2px_14px_rgba(16,185,129,0.45),inset_0_1px_0_rgba(255,255,255,0.2)] hover:brightness-[1.08] ${focusRing} focus-visible:ring-emerald-400/70 ${ringOffsetCls}`}
+                title="録音を再開"
+              >
+                <Play size={16} fill="currentColor" className="shrink-0" />
+                <span className="min-w-0 truncate">再開</span>
+              </motion.button>
+            ) : (
+              <motion.button
+                key="start"
+                onClick={startListening}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.12 }}
+                whileTap={{ scale: 0.98 }}
+                className={`${primaryBtnBase} bg-gradient-to-b from-emerald-400 to-emerald-600 text-white shadow-[0_2px_14px_rgba(16,185,129,0.45),inset_0_1px_0_rgba(255,255,255,0.2)] hover:brightness-[1.08] ${focusRing} focus-visible:ring-emerald-400/70 ${ringOffsetCls}`}
+                title="録音開始"
+              >
+                <Mic size={16} strokeWidth={2.25} className="shrink-0" />
+                <span className="min-w-0 truncate">録音</span>
+              </motion.button>
+            )}
+          </AnimatePresence>
+        </div>
 
-        {/* 発表終了（録音コントロールより視覚的に従属） */}
-        <PhaseTransitionButton darkMode={darkMode} compact />
-      </section>
-
-      <div className={`h-px shrink-0 ${divider}`} role="presentation" />
+        <div style={primaryTileStyle}>
+          <PhaseTransitionButton
+            darkMode={darkMode}
+            compact
+            compactClassName="h-full px-2.5 text-xs"
+          />
+        </div>
 
       {/* リセット（確認ダイアログ付き） */}
-      <AlertDialog.Root open={resetOpen} onOpenChange={setResetOpen}>
-        <AlertDialog.Trigger asChild>
-          <button
-            type="button"
-            title="文字起こし・用語・履歴などをすべてクリアします"
-            className={`flex w-full min-w-0 flex-row items-center justify-center gap-2 rounded-md border px-3 py-2 text-xs font-bold transition-colors ${focusRing} focus-visible:ring-amber-400/60 ${ringOffsetCls} ${
-              dk
-                ? 'border-amber-500/40 bg-amber-500/12 text-amber-300 hover:bg-amber-500/22'
-                : 'border-amber-300/90 bg-amber-50 text-amber-900 hover:bg-amber-100'
-            }`}
-            aria-label="すべてリセット"
-          >
-            <RotateCcw size={14} strokeWidth={2.5} className="shrink-0" />
-            リセット
-          </button>
-        </AlertDialog.Trigger>
+        <AlertDialog.Root open={resetOpen} onOpenChange={setResetOpen}>
+          <div className={layoutMode === 'mid' ? 'col-span-2' : ''} style={resetTileStyle}>
+            <AlertDialog.Trigger asChild>
+              <button
+                type="button"
+                title="文字起こし・用語・履歴などをすべてクリアします"
+                className={`${resetBtnBase} ${focusRing} focus-visible:ring-amber-400/60 ${ringOffsetCls} ${
+                  dk
+                    ? 'border-amber-500/50 bg-gradient-to-b from-amber-500/15 to-amber-600/8 text-amber-300 hover:from-amber-500/25 hover:to-amber-600/15 shadow-[inset_0_1px_0_rgba(251,191,36,0.12),0_1px_4px_rgba(0,0,0,0.25)]'
+                    : 'border-amber-300 bg-gradient-to-b from-white to-amber-50 text-amber-800 hover:from-amber-50 hover:to-amber-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_1px_3px_rgba(160,100,0,0.12)]'
+                }`}
+                aria-label="すべてリセット"
+              >
+                <RotateCcw size={14} strokeWidth={2.5} className="shrink-0" />
+                <span className="min-w-0 truncate">リセット</span>
+              </button>
+            </AlertDialog.Trigger>
+          </div>
 
-        <AlertDialog.Portal>
-          <AlertDialog.Overlay className="fixed inset-0 z-[100] bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
-          <AlertDialog.Content
-            className={`fixed left-1/2 top-1/2 z-[101] w-[min(92vw,380px)] -translate-x-1/2 -translate-y-1/2 rounded-xl border p-5 shadow-2xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ${
-              dk
-                ? 'border-slate-700 bg-[#0d0e1a] text-slate-100'
-                : 'border-slate-200 bg-white text-slate-900'
-            }`}
-          >
-            <div className="mb-3 flex items-center gap-2.5">
-              <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${dk ? 'bg-amber-500/15 text-amber-400' : 'bg-amber-100 text-amber-600'}`}>
-                <AlertTriangle size={18} strokeWidth={2} />
-              </span>
-              <AlertDialog.Title className="text-sm font-bold">
-                本当にリセットしますか？
-              </AlertDialog.Title>
-            </div>
-            <AlertDialog.Description className={`text-xs leading-relaxed ${dk ? 'text-slate-400' : 'text-slate-500'}`}>
-              文字起こし・用語・バブル・履歴がすべて消去されます。この操作は元に戻せません。
-            </AlertDialog.Description>
-            <div className="mt-4 flex justify-end gap-2">
-              <AlertDialog.Cancel asChild>
-                <button
-                  className={`rounded-md border px-4 py-1.5 text-xs font-bold transition-colors ${
-                    dk
-                      ? 'border-slate-600 text-slate-300 hover:bg-slate-800'
-                      : 'border-slate-300 text-slate-700 hover:bg-slate-50'
-                  }`}
-                >
-                  キャンセル
-                </button>
-              </AlertDialog.Cancel>
-              <AlertDialog.Action asChild>
-                <button
-                  onClick={onResetAll}
-                  className="rounded-md bg-red-600 px-4 py-1.5 text-xs font-bold text-white transition-colors hover:bg-red-500"
-                >
-                  リセットする
-                </button>
-              </AlertDialog.Action>
-            </div>
-          </AlertDialog.Content>
-        </AlertDialog.Portal>
-      </AlertDialog.Root>
+          <AlertDialog.Portal>
+            <AlertDialog.Overlay className="fixed inset-0 z-[100] bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
+            <AlertDialog.Content
+              className={`fixed left-1/2 top-1/2 z-[101] w-[min(92vw,380px)] -translate-x-1/2 -translate-y-1/2 rounded-xl border p-5 shadow-2xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ${
+                dk
+                  ? 'border-slate-700 bg-[#0d0e1a] text-slate-100'
+                  : 'border-slate-200 bg-white text-slate-900'
+              }`}
+            >
+              <div className="mb-3 flex items-center gap-2.5">
+                <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${dk ? 'bg-amber-500/15 text-amber-400' : 'bg-amber-100 text-amber-600'}`}>
+                  <AlertTriangle size={18} strokeWidth={2} />
+                </span>
+                <AlertDialog.Title className="text-sm font-bold">
+                  本当にリセットしますか？
+                </AlertDialog.Title>
+              </div>
+              <AlertDialog.Description className={`text-xs leading-relaxed ${dk ? 'text-slate-400' : 'text-slate-500'}`}>
+                文字起こし・用語・バブル・履歴がすべて消去されます。この操作は元に戻せません。
+              </AlertDialog.Description>
+              <div className="mt-4 flex justify-end gap-2">
+                <AlertDialog.Cancel asChild>
+                  <button
+                    className={`rounded-md border px-4 py-1.5 text-xs font-bold transition-colors ${
+                      dk
+                        ? 'border-slate-600 text-slate-300 hover:bg-slate-800'
+                        : 'border-slate-300 text-slate-700 hover:bg-slate-50'
+                    }`}
+                  >
+                    キャンセル
+                  </button>
+                </AlertDialog.Cancel>
+                <AlertDialog.Action asChild>
+                  <button
+                    onClick={onResetAll}
+                    className="rounded-md bg-red-600 px-4 py-1.5 text-xs font-bold text-white transition-colors hover:bg-red-500"
+                  >
+                    リセットする
+                  </button>
+                </AlertDialog.Action>
+              </div>
+            </AlertDialog.Content>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>
+      </section>
     </div>
   )
 }

--- a/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
+++ b/Frontend/src/presentation/windows/SystemControlWindow/index.tsx
@@ -14,14 +14,17 @@ import {
 const focusRing =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2'
 
-type ControlsLayoutMode = 'row' | 'column' | 'mid'
+type ControlsLayoutMode = 'wide' | 'tall' | 'middle' | 'tiny'
+
+const clamp = (min: number, max: number, value: number): number =>
+  Math.max(min, Math.min(max, value))
 
 export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const { onResetAll } = usePresentationShell()
   const dk = darkMode
   const [resetOpen, setResetOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement | null>(null)
-  const [layoutMode, setLayoutMode] = useState<ControlsLayoutMode>('column')
+  const [layoutMode, setLayoutMode] = useState<ControlsLayoutMode>('tall')
   const [viewportSize, setViewportSize] = useState({ width: SYSTEM_CONTROL_DOCK_MIN_WIDTH_PX, height: SYSTEM_CONTROL_DOCK_MIN_HEIGHT_PX })
 
   const { isListening, isPaused, startListening, pauseListening } = useTranscription()
@@ -43,36 +46,87 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
       setViewportSize({ width, height })
 
       const ratio = width / Math.max(height, 1)
-      if (ratio >= 1.34) setLayoutMode('row')
-      else if (ratio <= 0.78) setLayoutMode('column')
-      else setLayoutMode('mid')
+      const isTiny = width < 168 || height < 172
+      if (isTiny) setLayoutMode('tiny')
+      else if (ratio >= 1.45) setLayoutMode('wide')
+      else if (ratio <= 0.76) setLayoutMode('tall')
+      else setLayoutMode('middle')
     })
 
     observer.observe(el)
     return () => observer.disconnect()
   }, [])
 
-  const controlsLayoutClass = useMemo(() => {
-    if (layoutMode === 'row') return 'grid grid-cols-3 items-stretch gap-2'
-    if (layoutMode === 'column') return 'grid grid-cols-1 items-stretch gap-2'
-    return 'grid grid-cols-2 items-stretch gap-2'
-  }, [layoutMode])
+  const isTiny = layoutMode === 'tiny'
+
+  const controlsLayoutStyle = useMemo<React.CSSProperties>(() => {
+    if (isTiny) {
+      return {
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 1fr)',
+        gridTemplateAreas: '"record" "phase" "reset"',
+        gap: 6,
+        alignItems: 'stretch',
+      }
+    }
+
+    if (layoutMode === 'wide') {
+      return {
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr) minmax(72px, 0.68fr)',
+        gridTemplateAreas: '"record phase reset"',
+        gap: 8,
+        alignItems: 'center',
+      }
+    }
+
+    if (layoutMode === 'tall') {
+      return {
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 1fr)',
+        gridTemplateAreas: '"record" "phase" "reset"',
+        gap: 8,
+        alignItems: 'stretch',
+      }
+    }
+
+    return {
+      display: 'grid',
+      gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+      gridTemplateAreas: '"record phase" ". reset"',
+      columnGap: 8,
+      rowGap: 10,
+      alignItems: 'stretch',
+    }
+  }, [isTiny, layoutMode])
 
   const baseControlSize = useMemo(() => {
     const { width, height } = viewportSize
-    if (layoutMode === 'row') {
-      return Math.max(54, Math.min(92, Math.floor((width - 32) / 3)))
+    const contentWidth = Math.max(0, width - 20)
+    const contentHeight = Math.max(0, height - 20)
+
+    if (isTiny) {
+      return clamp(42, 56, Math.min(contentWidth, Math.floor((contentHeight - 16) / 2.75)))
     }
-    if (layoutMode === 'column') {
-      return Math.max(54, Math.min(92, Math.floor((height - 52) / 3)))
+
+    if (layoutMode === 'wide') {
+      return clamp(48, 76, Math.min(Math.floor((contentWidth - 16) / 2.68), contentHeight))
     }
-    const fromWidth = Math.floor((width - 24) / 2)
-    const fromHeight = Math.floor((height - 56) / 2)
-    return Math.max(52, Math.min(88, Math.min(fromWidth, fromHeight)))
-  }, [layoutMode, viewportSize])
+    if (layoutMode === 'tall') {
+      return clamp(48, 78, Math.min(contentWidth, Math.floor((contentHeight - 24) / 2.72)))
+    }
+    return clamp(46, 74, Math.min(Math.floor((contentWidth - 8) / 2), Math.floor((contentHeight - 14) / 1.88)))
+  }, [isTiny, layoutMode, viewportSize])
 
   const primaryTileStyle = { minHeight: baseControlSize, height: baseControlSize }
-  const resetTileStyle = { minHeight: Math.round(baseControlSize * 0.88), height: Math.round(baseControlSize * 0.88) }
+  const resetTileStyle = {
+    gridArea: 'reset',
+    justifySelf: layoutMode === 'middle' ? 'end' : 'stretch',
+    marginTop: layoutMode === 'tall' ? 8 : 0,
+    minHeight: Math.round(baseControlSize * 0.84),
+    height: Math.round(baseControlSize * 0.84),
+    width: layoutMode === 'middle' ? 'min(100%, 124px)' : '100%',
+  } satisfies React.CSSProperties
 
   return (
     <div
@@ -85,8 +139,8 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
         dk ? 'bg-[#0d0e1a] text-slate-200' : 'bg-white text-slate-800'
       }`}
     >
-      <section aria-label="操作コントロール" className={controlsLayoutClass}>
-        <div style={primaryTileStyle}>
+      <section aria-label="操作コントロール" style={controlsLayoutStyle}>
+        <div style={{ ...primaryTileStyle, gridArea: 'record' }}>
           <AnimatePresence mode="wait">
             {isListening ? (
               <motion.button
@@ -138,7 +192,7 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
           </AnimatePresence>
         </div>
 
-        <div style={primaryTileStyle}>
+        <div style={{ ...primaryTileStyle, gridArea: 'phase' }}>
           <PhaseTransitionButton
             darkMode={darkMode}
             compact
@@ -148,15 +202,15 @@ export const SystemControlWindow: React.FC<WindowProps> = ({ darkMode = true }) 
 
       {/* リセット（確認ダイアログ付き） */}
         <AlertDialog.Root open={resetOpen} onOpenChange={setResetOpen}>
-          <div className={layoutMode === 'mid' ? 'col-span-2' : ''} style={resetTileStyle}>
+          <div style={resetTileStyle}>
             <AlertDialog.Trigger asChild>
               <button
                 type="button"
                 title="文字起こし・用語・履歴などをすべてクリアします"
                 className={`${resetBtnBase} ${focusRing} focus-visible:ring-amber-400/60 ${ringOffsetCls} ${
                   dk
-                    ? 'border-amber-500/50 bg-gradient-to-b from-amber-500/15 to-amber-600/8 text-amber-300 hover:from-amber-500/25 hover:to-amber-600/15 shadow-[inset_0_1px_0_rgba(251,191,36,0.12),0_1px_4px_rgba(0,0,0,0.25)]'
-                    : 'border-amber-300 bg-gradient-to-b from-white to-amber-50 text-amber-800 hover:from-amber-50 hover:to-amber-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_1px_3px_rgba(160,100,0,0.12)]'
+                    ? 'border-slate-600/55 bg-gradient-to-b from-slate-800/70 to-slate-900/70 text-slate-400 hover:border-amber-500/55 hover:text-amber-300 hover:from-amber-500/14 hover:to-amber-600/8 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]'
+                    : 'border-slate-200 bg-gradient-to-b from-white to-slate-50 text-slate-500 hover:border-amber-300 hover:text-amber-800 hover:from-amber-50 hover:to-amber-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_1px_2px_rgba(15,23,42,0.06)]'
                 }`}
                 aria-label="すべてリセット"
               >

--- a/Frontend/test-setup.ts
+++ b/Frontend/test-setup.ts
@@ -1,8 +1,6 @@
-import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import '@happy-dom/global-registrator/register'
 import { afterEach } from 'bun:test'
 import { cleanup } from '@testing-library/react'
-
-GlobalRegistrator.register()
 
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
## 概要
- 操作ウィンドウの3ボタンを縦横比に応じて配置し、録音・発表終了・リセットの重要度が伝わる見た目に整理しました。
- 操作ウィンドウの最小幅・最小高さを定数化し、ドラッグリサイズ時にも高さ下限が反映されるようにしました。
- このブランチ向けのテスト仕様書を追加し、React Testing Library 用の happy-dom 登録を整理しました。

## テスト
- `cd Frontend && bun run build`
- `cd Frontend && bun test`（68件成功）


Made with [Cursor](https://cursor.com)