### PR TITLE
Step1: SSEスコア基盤の導入

### DIFF
--- a/Frontend/docs/orders/order-003.md
+++ b/Frontend/docs/orders/order-003.md
@@ -478,6 +478,6 @@ useEffect(() => {
 
 ## 次のアクション
 
-1. `feature/sse-foundation` ブランチを切って Step 1 に着手
+1. `feature/sse-foundation` ブランチで Step 1 を実装・確認（完了）
 2. 各 Step 完了時にブラウザで動作確認してからマージ
 3. Step 5 完了後に `SCORE_SCALE_FACTOR` を調整

--- a/Frontend/docs/tests/test-spec-008.md
+++ b/Frontend/docs/tests/test-spec-008.md
@@ -1,0 +1,45 @@
+# test-spec-008: order-003 Step1（sse-foundation）検証
+
+## 日付
+
+2026-05-28
+
+## 対象ファイル
+
+- `Frontend/src/domain/interfaces/IScoreUpdateStrategy.ts`
+- `Frontend/src/domain/interfaces/index.ts`
+- `Frontend/src/stores/termStore.ts`
+- `Frontend/src/stores/__tests__/termStore.test.ts`
+
+## テストの目的
+
+ブランチ `feature/sse-foundation` の Step1 実装において、以降のスコア一元化で必要になる土台が正しく導入されていることを確認する。
+
+- スコア更新戦略インターフェース（`IScoreUpdateStrategy`）が定義・公開されていること
+- `termStore` に `updateTermScore` が追加され、対象IDの `term.score` を更新できること
+
+## テスト項目
+
+| # | テストケース | 種別 | 期待結果 |
+|---|---|---|---|
+| 1 | `IScoreUpdateStrategy` の公開 | 単体 | `domain/interfaces/index.ts` から参照可能 |
+| 2 | `updateTermScore` の更新動作 | 単体 | 対象IDの `score` のみ更新される |
+| 3 | 既存 store テストの回帰 | 単体 | 既存ケースがすべて成功する |
+
+## 実行結果
+
+### 実行コマンド
+
+```bash
+cd Frontend
+bun test src/stores/__tests__/termStore.test.ts
+```
+
+| コマンド | 結果 | メモ |
+|----------|------|------|
+| `bun test src/stores/__tests__/termStore.test.ts` | 合格 | 12件成功、0件失敗 |
+
+## 気づき・注意点
+
+- Step1 は「スコア更新の口」を作る段階であり、しきい値フィルタ・頻度加算・クリック加算・描画切替はこの時点では未導入。
+- `order-003` の Step2 以降で `IScoreUpdateStrategy` と `updateTermScore` を利用して機能を段階的に接続する。

--- a/Frontend/src/domain/interfaces/IScoreUpdateStrategy.ts
+++ b/Frontend/src/domain/interfaces/IScoreUpdateStrategy.ts
@@ -1,0 +1,6 @@
+export interface IScoreUpdateStrategy {
+  /** 頻度加算: 現在スコアと出現回数から新スコアを返す */
+  onFrequency(currentScore: number, count: number): number
+  /** クリック加算: 現在スコアから新スコアを返す */
+  onClick(currentScore: number): number
+}

--- a/Frontend/src/domain/interfaces/index.ts
+++ b/Frontend/src/domain/interfaces/index.ts
@@ -1,3 +1,4 @@
 export * from './IImportanceStrategy'
+export * from './IScoreUpdateStrategy'
 export * from './ITranscriptionService'
 export * from './IPhase'

--- a/Frontend/src/stores/__tests__/termStore.test.ts
+++ b/Frontend/src/stores/__tests__/termStore.test.ts
@@ -34,6 +34,14 @@ describe('termStore', () => {
     expect(useTermStore.getState().activeTerms).toHaveLength(1)
   })
 
+  it('updateTermScore で対象のスコアを更新できる', () => {
+    useTermStore.getState().addTerms([term1, term2])
+    useTermStore.getState().updateTermScore('1', 9.5)
+    const terms = useTermStore.getState().activeTerms
+    expect(terms.find((t) => t.id === '1')?.score).toBe(9.5)
+    expect(terms.find((t) => t.id === '2')?.score).toBe(2)
+  })
+
   it('用語を選択できる', () => {
     useTermStore.getState().addTerms([term1])
     useTermStore.getState().selectTerm(term1)

--- a/Frontend/src/stores/termStore.ts
+++ b/Frontend/src/stores/termStore.ts
@@ -11,6 +11,7 @@ interface TermState {
   termClickWeights: Record<string, number>
 
   addTerms: (terms: Term[]) => void
+  updateTermScore: (id: string, score: number) => void
   removeTermById: (id: string) => void
   /** デモ重要語マーキングで注入した用語だけ除去（prefix は mockImportantTerms と一致させる） */
   stripDemoImportantTerms: () => void
@@ -45,6 +46,12 @@ export const useTermStore = create<TermState>((set) => ({
     }
     return { activeTerms: [...state.activeTerms, ...newTerms] }
   }),
+
+  updateTermScore: (id, score) => set((state) => ({
+    activeTerms: state.activeTerms.map((term) => (
+      term.id === id ? { ...term, score } : term
+    )),
+  })),
 
   removeTermById: (id) => set((state) => ({
     activeTerms: state.activeTerms.filter(t => t.id !== id),


### PR DESCRIPTION
## Summary
- `termStore` に `updateTermScore` を追加し、`term.score` を明示更新できる基盤を導入
- `IScoreUpdateStrategy` を追加して、頻度/クリック加算ロジックを差し替え可能な契約として定義
- Step1完了時点の検証内容を `test-spec-008` として追加し、`order-003` の次アクションを更新

## Test plan
- [x] `cd Frontend && bun test src/stores/__tests__/termStore.test.ts`
- [x] ドキュメント差分を目視確認（`order-003`, `test-spec-008`）

Made with [Cursor](https://cursor.com)