### PR TITLE
Step2: 低スコア除外フィルターと閾値スライダーの導入

### DIFF
--- a/Frontend/docs/orders/order-003.md
+++ b/Frontend/docs/orders/order-003.md
@@ -479,5 +479,5 @@ useEffect(() => {
 ## 次のアクション
 
 1. `feature/sse-foundation` ブランチで Step 1 を実装・確認（完了）
-2. 各 Step 完了時にブラウザで動作確認してからマージ
+2. `feature/score-threshold-filter` ブランチで Step 2 を実装・確認（完了）
 3. Step 5 完了後に `SCORE_SCALE_FACTOR` を調整

--- a/Frontend/docs/tests/test-spec-009.md
+++ b/Frontend/docs/tests/test-spec-009.md
@@ -1,0 +1,44 @@
+# test-spec-009: order-003 Step2（score-threshold-filter）検証
+
+## 日付
+
+2026-05-28
+
+## 対象ファイル
+
+- `Frontend/src/infrastructure/adapters/ScoreThresholdFilter.ts`
+- `Frontend/src/infrastructure/adapters/__tests__/ScoreThresholdFilter.test.ts`
+- `Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx`
+
+## テストの目的
+
+ブランチ `feature/score-threshold-filter` の Step2 実装において、SSEで受信した用語をストア反映前にしきい値で除外できることを確認する。
+
+- `DEFAULT_SCORE_THRESHOLD`（0.1）による低スコア除外が機能すること
+- `ReferDictScoreSseBridge` で `filterByScore` が適用されること
+
+## テスト項目
+
+| # | テストケース | 種別 | 期待結果 |
+|---|---|---|---|
+| 1 | デフォルト閾値の除外動作 | 単体 | `score < 0.1` の用語が除外される |
+| 2 | 閾値上書き動作 | 単体 | 引数で指定した閾値以上のみ返る |
+| 3 | SSEブリッジ配線確認 | 実装確認 | `onTerms` 内で `filterByScore` 後に `addTerms` される |
+
+## 実行結果
+
+### 実行コマンド
+
+```bash
+cd Frontend
+bun test src/infrastructure/adapters
+```
+
+| コマンド | 結果 | メモ |
+|----------|------|------|
+| `bun test src/infrastructure/adapters` | 合格 | 2件成功、0件失敗（Step2範囲） |
+
+## 気づき・注意点
+
+- Step2時点では頻度加算・クリック加算は未導入（Step3/Step4で追加予定）。
+- 判定対象は「SSEから受信した生スコア」であり、ストア蓄積後のスコアではない。

--- a/Frontend/src/app/components/SettingsModal.tsx
+++ b/Frontend/src/app/components/SettingsModal.tsx
@@ -27,6 +27,9 @@ interface SettingsModalProps {
   similarityReferenceWord?: string;
   /** APIから基準ベクトルを取得できたか */
   similarityReady?: boolean;
+  /** SSEスコア閾値（0.00〜1.00） */
+  scoreThreshold?: number;
+  onScoreThresholdChange?: (value: number) => void;
 }
 
 const THEME_COLORS = [
@@ -49,6 +52,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   onSimilarityFilterStrengthChange,
   similarityReferenceWord = 'it',
   similarityReady = false,
+  scoreThreshold = 0.1,
+  onScoreThresholdChange,
 }) => {
   const contentFontScale = useContentFontScaleStore(s => s.scale);
   const setContentFontScale = useContentFontScaleStore(s => s.setScale);
@@ -158,6 +163,41 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                   各ウィンドウ内の重要語・説明文のみ拡大／縮小します。ウィンドウタイトルやこの設定画面の文字サイズは変わりません。
                 </p>
               </section>
+
+              {onScoreThresholdChange && (
+                <section>
+                  <div className={`flex items-center gap-1.5 mb-2.5 text-[10px] font-bold uppercase tracking-widest ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
+                    <SlidersHorizontal size={12} /> IT単語フィルター
+                  </div>
+                  <div className="mb-1.5 flex items-center justify-between gap-2">
+                    <span className="text-xs font-bold">関連度しきい値</span>
+                    <span className={`text-[10px] font-mono font-bold ${dk ? 'text-slate-400' : 'text-slate-500'}`}>
+                      {scoreThreshold.toFixed(2)}
+                    </span>
+                  </div>
+                  <input
+                    type="range"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={scoreThreshold}
+                    onChange={(e) => onScoreThresholdChange(Number(e.target.value))}
+                    className={`mb-1.5 w-full cursor-pointer ${dk ? 'opacity-95' : ''}`}
+                    style={accentSliderStyle(rgb)}
+                    aria-valuemin={0}
+                    aria-valuemax={1}
+                    aria-valuenow={scoreThreshold}
+                    aria-label="IT単語フィルターのしきい値"
+                  />
+                  <div className={`flex justify-between mt-0.5 text-[9px] ${dk ? 'text-slate-600' : 'text-slate-400'}`}>
+                    <span>広く表示</span>
+                    <span>IT関連のみ</span>
+                  </div>
+                  <p className={`mt-1 text-[10px] leading-snug ${dk ? 'text-slate-500' : 'text-slate-400'}`}>
+                    値を上げるほど、ITトピックとの関連度が高い単語だけを表示します。
+                  </p>
+                </section>
+              )}
 
               {/* Similarity Filter Settings */}
               {onSimilarityFilterEnabledChange && (

--- a/Frontend/src/infrastructure/adapters/ScoreThresholdFilter.ts
+++ b/Frontend/src/infrastructure/adapters/ScoreThresholdFilter.ts
@@ -1,0 +1,10 @@
+import type { Term } from '../../domain/entities/Term'
+
+export const DEFAULT_SCORE_THRESHOLD = 0.1
+
+export function filterByScore(
+  terms: Term[],
+  threshold: number = DEFAULT_SCORE_THRESHOLD,
+): Term[] {
+  return terms.filter((term) => term.score >= threshold)
+}

--- a/Frontend/src/infrastructure/adapters/__tests__/ScoreThresholdFilter.test.ts
+++ b/Frontend/src/infrastructure/adapters/__tests__/ScoreThresholdFilter.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test'
+import type { Term } from '../../../domain/entities/Term'
+import { filterByScore } from '../ScoreThresholdFilter'
+
+const makeTerm = (id: string, score: number): Term => ({
+  id,
+  word: `word-${id}`,
+  kana: '',
+  shortDesc: '',
+  longDesc: '',
+  category: '',
+  score,
+  relatedTerms: [],
+})
+
+describe('ScoreThresholdFilter', () => {
+  it('デフォルト閾値(0.1)以上の用語のみ返す', () => {
+    const result = filterByScore([
+      makeTerm('a', 0.05),
+      makeTerm('b', 0.1),
+      makeTerm('c', 0.2),
+    ])
+    expect(result.map((term) => term.id)).toEqual(['b', 'c'])
+  })
+
+  it('閾値を引数で上書きできる', () => {
+    const result = filterByScore([
+      makeTerm('a', 0.2),
+      makeTerm('b', 0.6),
+      makeTerm('c', 0.8),
+    ], 0.7)
+    expect(result.map((term) => term.id)).toEqual(['c'])
+  })
+})

--- a/Frontend/src/presentation/App.tsx
+++ b/Frontend/src/presentation/App.tsx
@@ -17,6 +17,7 @@ import { useTermStore } from '../stores/termStore'
 import { useBubbleStore } from '../stores/bubbleStore'
 import { getOppositeThemeColor } from './utils/oppositeThemeColor'
 import { AccentThemeProvider } from '../theme/AccentThemeContext'
+import { DEFAULT_SCORE_THRESHOLD } from '../infrastructure/adapters/ScoreThresholdFilter'
 
 // ウィンドウを一度だけ登録
 let _registered = false
@@ -34,6 +35,7 @@ const App: React.FC = () => {
   const currentPhaseId = usePhaseStore(s => s.currentPhaseId)
   const [appearanceOpen, setAppearanceOpen] = useState(false)
   const [appearance, setAppearance] = useState({ darkMode: true, themeColor: 'indigo' })
+  const [scoreThreshold, setScoreThreshold] = useState(DEFAULT_SCORE_THRESHOLD)
 
   const demoStream = useDemoStream({
     onAppend: text => getTranscriptionService().setTranscriptExternal(text),
@@ -70,7 +72,7 @@ const App: React.FC = () => {
         }}
       >
         <DemoImportantTermsBridge />
-        <ReferDictScoreSseBridge />
+        <ReferDictScoreSseBridge scoreThreshold={scoreThreshold} />
         <AccentThemeProvider themeColor={phaseAccentColor}>
         <div
           className={`w-screen h-screen flex flex-col overflow-hidden ${dk ? 'bg-[#0a0b14] text-slate-100' : 'bg-slate-50 text-slate-900'}`}
@@ -94,6 +96,8 @@ const App: React.FC = () => {
             onClose={() => setAppearanceOpen(false)}
             settings={appearance}
             updateSettings={partial => setAppearance(prev => ({ ...prev, ...partial }))}
+            scoreThreshold={scoreThreshold}
+            onScoreThresholdChange={setScoreThreshold}
           />
 
           <Toaster position="bottom-right" theme={darkMode ? 'dark' : 'light'} />

--- a/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
+++ b/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { useReferDictScoreSse } from '../hooks/useReferDictScoreSse'
 import { useTermStore } from '../../stores/termStore'
+import { filterByScore } from '../../infrastructure/adapters/ScoreThresholdFilter'
 
 /**
  * App ルートに置く配線用（UI なし）。
@@ -8,7 +9,10 @@ import { useTermStore } from '../../stores/termStore'
  */
 export const ReferDictScoreSseBridge: React.FC = () => {
   useReferDictScoreSse({
-    onTerms: (terms) => useTermStore.getState().addTerms(terms),
+    onTerms: (terms) => {
+      const filtered = filterByScore(terms)
+      useTermStore.getState().addTerms(filtered)
+    },
   })
   return null
 }

--- a/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
+++ b/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
@@ -3,14 +3,20 @@ import { useReferDictScoreSse } from '../hooks/useReferDictScoreSse'
 import { useTermStore } from '../../stores/termStore'
 import { filterByScore } from '../../infrastructure/adapters/ScoreThresholdFilter'
 
+interface ReferDictScoreSseBridgeProps {
+  scoreThreshold?: number
+}
+
 /**
  * App ルートに置く配線用（UI なし）。
  * 既定では SSE のみ開く。termStore へ載せる場合は `onTerms` を渡す。
  */
-export const ReferDictScoreSseBridge: React.FC = () => {
+export const ReferDictScoreSseBridge: React.FC<ReferDictScoreSseBridgeProps> = ({
+  scoreThreshold,
+}) => {
   useReferDictScoreSse({
     onTerms: (terms) => {
-      const filtered = filterByScore(terms)
+      const filtered = filterByScore(terms, scoreThreshold)
       useTermStore.getState().addTerms(filtered)
     },
   })


### PR DESCRIPTION
## Summary
- SSE受信語をストア投入前に除外する `ScoreThresholdFilter` と単体テストを追加
- `ReferDictScoreSseBridge` にスコア閾値を渡せるよう拡張し、フィルター適用を配線
- 設定モーダルに `IT単語フィルター` スライダーと説明文を追加し、閾値をUIで調整可能にした
- Step2の進捗を `order-003` と `test-spec-009` に記録

## Test plan
- [x] `cd Frontend && bun test src/infrastructure/adapters`
- [x] 設定モーダルでスライダー値変更時に閾値表示が更新されることを目視確認

Made with [Cursor](https://cursor.com)