### PR TITLE
Step3: 頻度スコアアダプタの導入

### DIFF
--- a/Frontend/docs/orders/order-003.md
+++ b/Frontend/docs/orders/order-003.md
@@ -480,4 +480,5 @@ useEffect(() => {
 
 1. `feature/sse-foundation` ブランチで Step 1 を実装・確認（完了）
 2. `feature/score-threshold-filter` ブランチで Step 2 を実装・確認（完了）
-3. Step 5 完了後に `SCORE_SCALE_FACTOR` を調整
+3. `feature/frequency-adapter` ブランチで Step 3 を実装・確認（完了）
+4. Step 5 完了後に `SCORE_SCALE_FACTOR` を調整

--- a/Frontend/docs/tests/test-spec-010.md
+++ b/Frontend/docs/tests/test-spec-010.md
@@ -1,0 +1,48 @@
+# test-spec-010: order-003 Step3（frequency-adapter）検証
+
+## 日付
+
+2026-05-28
+
+## 対象ファイル
+
+- `Frontend/src/infrastructure/adapters/DefaultScoreUpdateStrategy.ts`
+- `Frontend/src/infrastructure/adapters/FrequencyScoreAdapter.ts`
+- `Frontend/src/infrastructure/adapters/__tests__/DefaultScoreUpdateStrategy.test.ts`
+- `Frontend/src/infrastructure/adapters/__tests__/FrequencyScoreAdapter.test.ts`
+- `Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx`
+
+## テストの目的
+
+ブランチ `feature/frequency-adapter` の Step3 実装において、同一用語の再出現時に `term.score` へ頻度加算できることを確認する。
+
+- 初出は `toAdd`、2回目以降は `toUpdate` に振り分けられること
+- `DefaultScoreUpdateStrategy` の既定加算量が意図どおりであること
+- `ReferDictScoreSseBridge` が `filterByScore` 後に頻度アダプタを経由すること
+
+## テスト項目
+
+| # | テストケース | 種別 | 期待結果 |
+|---|---|---|---|
+| 1 | `DefaultScoreUpdateStrategy` の加算動作 | 単体 | `onFrequency` と `onClick` が固定量加算する |
+| 2 | `FrequencyScoreAdapter` の初出・再出現判定 | 単体 | 初出は `toAdd`、再出現は `toUpdate` |
+| 3 | `FrequencyScoreAdapter.reset` | 単体 | カウントが初期化され再び初出扱いになる |
+| 4 | SSEブリッジ配線確認 | 実装確認 | `filterByScore` 後に `adapter.adapt` と `updateTermScore` が呼ばれる |
+
+## 実行結果
+
+### 実行コマンド
+
+```bash
+cd Frontend
+bun test src/infrastructure/adapters
+```
+
+| コマンド | 結果 | メモ |
+|----------|------|------|
+| `bun test src/infrastructure/adapters` | 合格 | 7件成功、0件失敗 |
+
+## 気づき・注意点
+
+- Step3 では頻度加算のみ導入し、クリック加算の統一は Step4 で実施する。
+- セッションリセット時は `ReferDictScoreSseBridge` 内の `adapter.reset()` でカウントを初期化する。

--- a/Frontend/src/infrastructure/adapters/DefaultScoreUpdateStrategy.ts
+++ b/Frontend/src/infrastructure/adapters/DefaultScoreUpdateStrategy.ts
@@ -1,0 +1,16 @@
+import type { IScoreUpdateStrategy } from '../../domain/interfaces'
+
+export const FREQUENCY_DELTA = 0.05
+export const CLICK_DELTA = 0.1
+
+export class DefaultScoreUpdateStrategy implements IScoreUpdateStrategy {
+  onFrequency(currentScore: number, _count: number): number {
+    return currentScore + FREQUENCY_DELTA
+  }
+
+  onClick(currentScore: number): number {
+    return currentScore + CLICK_DELTA
+  }
+}
+
+export const defaultScoreUpdateStrategy = new DefaultScoreUpdateStrategy()

--- a/Frontend/src/infrastructure/adapters/FrequencyScoreAdapter.ts
+++ b/Frontend/src/infrastructure/adapters/FrequencyScoreAdapter.ts
@@ -1,0 +1,40 @@
+import type { Term } from '../../domain/entities/Term'
+import type { IScoreUpdateStrategy } from '../../domain/interfaces'
+import { useTermStore } from '../../stores/termStore'
+
+interface TermScoreUpdate {
+  id: string
+  score: number
+}
+
+export class FrequencyScoreAdapter {
+  private counts = new Map<string, number>()
+
+  constructor(private strategy: IScoreUpdateStrategy) {}
+
+  adapt(terms: Term[]): { toAdd: Term[]; toUpdate: TermScoreUpdate[] } {
+    const toAdd: Term[] = []
+    const toUpdate: TermScoreUpdate[] = []
+
+    for (const term of terms) {
+      const prev = this.counts.get(term.id) ?? 0
+      const next = prev + 1
+      this.counts.set(term.id, next)
+
+      if (prev === 0) {
+        toAdd.push(term)
+      } else {
+        const currentScore = useTermStore.getState().activeTerms
+          .find((activeTerm) => activeTerm.id === term.id)?.score ?? term.score
+        const newScore = this.strategy.onFrequency(currentScore, next)
+        toUpdate.push({ id: term.id, score: newScore })
+      }
+    }
+
+    return { toAdd, toUpdate }
+  }
+
+  reset(): void {
+    this.counts.clear()
+  }
+}

--- a/Frontend/src/infrastructure/adapters/__tests__/DefaultScoreUpdateStrategy.test.ts
+++ b/Frontend/src/infrastructure/adapters/__tests__/DefaultScoreUpdateStrategy.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  CLICK_DELTA,
+  DefaultScoreUpdateStrategy,
+  FREQUENCY_DELTA,
+} from '../DefaultScoreUpdateStrategy'
+
+describe('DefaultScoreUpdateStrategy', () => {
+  const strategy = new DefaultScoreUpdateStrategy()
+
+  it('onFrequency は固定量を加算する', () => {
+    expect(strategy.onFrequency(0.4, 3)).toBe(0.4 + FREQUENCY_DELTA)
+  })
+
+  it('onClick は固定量を加算する', () => {
+    expect(strategy.onClick(0.4)).toBe(0.4 + CLICK_DELTA)
+  })
+})

--- a/Frontend/src/infrastructure/adapters/__tests__/FrequencyScoreAdapter.test.ts
+++ b/Frontend/src/infrastructure/adapters/__tests__/FrequencyScoreAdapter.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import type { Term } from '../../../domain/entities/Term'
+import type { IScoreUpdateStrategy } from '../../../domain/interfaces'
+import { useTermStore } from '../../../stores/termStore'
+import { FrequencyScoreAdapter } from '../FrequencyScoreAdapter'
+
+const makeTerm = (id: string, score: number): Term => ({
+  id,
+  word: `word-${id}`,
+  kana: '',
+  shortDesc: '',
+  longDesc: '',
+  category: '',
+  score,
+  relatedTerms: [],
+})
+
+const strategy: IScoreUpdateStrategy = {
+  onFrequency: (currentScore, count) => currentScore + count * 0.1,
+  onClick: (currentScore) => currentScore + 0.1,
+}
+
+describe('FrequencyScoreAdapter', () => {
+  beforeEach(() => {
+    useTermStore.setState({
+      activeTerms: [],
+      selectedTerm: null,
+      searchHistory: [],
+      pinnedTermIds: new Set(),
+      termClickWeights: {},
+    })
+  })
+
+  it('初出の用語は toAdd に入る', () => {
+    const adapter = new FrequencyScoreAdapter(strategy)
+    const result = adapter.adapt([makeTerm('a', 0.5)])
+    expect(result.toAdd.map((term) => term.id)).toEqual(['a'])
+    expect(result.toUpdate).toEqual([])
+  })
+
+  it('2回目以降は strategy で加算して toUpdate を返す', () => {
+    const adapter = new FrequencyScoreAdapter(strategy)
+    useTermStore.getState().addTerms([makeTerm('a', 1.0)])
+    adapter.adapt([makeTerm('a', 1.0)])
+    const second = adapter.adapt([makeTerm('a', 1.0)])
+    expect(second.toAdd).toEqual([])
+    expect(second.toUpdate).toEqual([{ id: 'a', score: 1.2 }])
+  })
+
+  it('reset 後は同じ用語を再び初出扱いにする', () => {
+    const adapter = new FrequencyScoreAdapter(strategy)
+    adapter.adapt([makeTerm('a', 0.5)])
+    adapter.reset()
+    const result = adapter.adapt([makeTerm('a', 0.6)])
+    expect(result.toAdd.map((term) => term.id)).toEqual(['a'])
+  })
+})

--- a/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
+++ b/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
@@ -1,7 +1,10 @@
 import type React from 'react'
+import { useEffect, useRef } from 'react'
 import { useReferDictScoreSse } from '../hooks/useReferDictScoreSse'
 import { useTermStore } from '../../stores/termStore'
 import { filterByScore } from '../../infrastructure/adapters/ScoreThresholdFilter'
+import { defaultScoreUpdateStrategy } from '../../infrastructure/adapters/DefaultScoreUpdateStrategy'
+import { FrequencyScoreAdapter } from '../../infrastructure/adapters/FrequencyScoreAdapter'
 
 interface ReferDictScoreSseBridgeProps {
   scoreThreshold?: number
@@ -14,10 +17,30 @@ interface ReferDictScoreSseBridgeProps {
 export const ReferDictScoreSseBridge: React.FC<ReferDictScoreSseBridgeProps> = ({
   scoreThreshold,
 }) => {
+  const adapterRef = useRef<FrequencyScoreAdapter | null>(null)
+  if (!adapterRef.current) {
+    adapterRef.current = new FrequencyScoreAdapter(defaultScoreUpdateStrategy)
+  }
+
+  useEffect(() => {
+    const unsub = useTermStore.subscribe((state, prev) => {
+      const wasReset = prev.activeTerms.length > 0
+        && state.activeTerms.length === 0
+        && state.searchHistory.length === 0
+        && state.pinnedTermIds.size === 0
+      if (wasReset) adapterRef.current?.reset()
+    })
+    return unsub
+  }, [])
+
   useReferDictScoreSse({
     onTerms: (terms) => {
       const filtered = filterByScore(terms, scoreThreshold)
-      useTermStore.getState().addTerms(filtered)
+      const adapted = adapterRef.current?.adapt(filtered)
+      if (!adapted) return
+      const store = useTermStore.getState()
+      store.addTerms(adapted.toAdd)
+      adapted.toUpdate.forEach(({ id, score }) => store.updateTermScore(id, score))
     },
   })
   return null


### PR DESCRIPTION
## Summary
- `DefaultScoreUpdateStrategy` / `FrequencyScoreAdapter` を追加し、再出現語の `term.score` 更新経路を実装
- `ReferDictScoreSseBridge` を `filterByScore -> adapt -> add/update` フローへ変更し、セッションリセット時の `adapter.reset()` も追加
- Step3 の検証内容を `test-spec-010` に追記し、`order-003` の進捗を Step3 完了へ更新

## Test plan
- [x] `cd Frontend && bun test src/infrastructure/adapters`

Made with [Cursor](https://cursor.com)