### PR TITLE
fix: WebSpeechの強制継続ロジックを削除

### DIFF
--- a/Frontend/src/app/hooks/useSpeechRecognition.ts
+++ b/Frontend/src/app/hooks/useSpeechRecognition.ts
@@ -55,9 +55,8 @@ export const useSpeechRecognition = (): UseSpeechRecognitionReturn => {
     };
 
     recognition.onend = () => {
-      if (listeningRef.current) {
-        try { recognition.start(); } catch (e) { }
-      }
+      listeningRef.current = false;
+      setIsListening(false);
     };
 
     recognitionRef.current = recognition;

--- a/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
+++ b/Frontend/src/infrastructure/speech/WebSpeechTranscriptionService.ts
@@ -76,11 +76,7 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
         }
       }
 
-      // 不正確でも文字を残したい要件のため、途中文字列が短くなる更新では縮めない
-      const nextInterimTrimmed = nextInterim.trim()
-      if (nextInterimTrimmed.length >= this.interimTranscript.trim().length) {
-        this.interimTranscript = nextInterim
-      }
+      this.interimTranscript = nextInterim
       this.transcript = `${this.finalTranscript}${this.interimTranscript}`
       this.notify()
     }
@@ -92,9 +88,11 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
     }
 
     recognition.onend = () => {
-      if (this.isRunning) {
-        try { recognition.start() } catch { /* ignore */ }
+      this.isRunning = false
+      if (this.status === 'listening') {
+        this.status = 'idle'
       }
+      this.notify()
     }
 
     this.recognition = recognition
@@ -236,20 +234,8 @@ export class WebSpeechTranscriptionService implements ITranscriptionService {
     try {
       this.recognition.start()
     } catch {
-      // ブラウザ状態で start() が失敗するケースがあるため、1回だけ再初期化して再試行する。
-      this.initRecognition()
-      if (!this.recognition) {
-        this.status = 'error'
-        this.isRunning = false
-        this.notify()
-        return
-      }
-      try {
-        this.recognition.start()
-      } catch {
-        this.status = 'error'
-        this.isRunning = false
-      }
+      this.status = 'error'
+      this.isRunning = false
     }
     this.notify()
   }


### PR DESCRIPTION
## Summary
- `WebSpeechTranscriptionService` の `onend` 自動再開を削除し、認識終了時はそのまま停止状態へ遷移
- `startListening` の再初期化・再試行ロジックを削除し、失敗時は `error` として扱うよう整理
- interimテキストの補正ロジックを削除し、WebSpeechの結果をそのまま反映
- 旧 `useSpeechRecognition` 側に残っていた `onend` 自動再開も削除

## Test plan
- [x] `cd Frontend && bun test src/presentation/hooks/__tests__/transcriptionModeSync.test.ts src/presentation/hooks/__tests__/useTranscriptionModeBroadcast.test.tsx`
- [x] `cd Frontend && bun run build`

Made with [Cursor](https://cursor.com)