### PR TITLE
Step4: クリックスコア更新のサービス化

### DIFF
--- a/Frontend/docs/orders/order-003.md
+++ b/Frontend/docs/orders/order-003.md
@@ -481,4 +481,5 @@ useEffect(() => {
 1. `feature/sse-foundation` ブランチで Step 1 を実装・確認（完了）
 2. `feature/score-threshold-filter` ブランチで Step 2 を実装・確認（完了）
 3. `feature/frequency-adapter` ブランチで Step 3 を実装・確認（完了）
-4. Step 5 完了後に `SCORE_SCALE_FACTOR` を調整
+4. `feature/click-score-service` ブランチで Step 4 を実装・確認（完了）
+5. Step 5 完了後に `SCORE_SCALE_FACTOR` を調整

--- a/Frontend/docs/tests/test-spec-013.md
+++ b/Frontend/docs/tests/test-spec-013.md
@@ -1,0 +1,44 @@
+# test-spec-013: order-003 Step4（click-score-service）検証
+
+## 日付
+
+2026-05-28
+
+## 対象ファイル
+
+- `Frontend/src/presentation/hooks/useScoreUpdate.ts`
+- `Frontend/src/presentation/windows/BubbleCloudWindow/index.tsx`
+- `Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx`
+- `Frontend/src/presentation/windows/TranscriptionWindow/index.tsx`
+
+## テストの目的
+
+ブランチ `feature/click-score-service` の Step4 実装において、クリック起点のスコア加算を `useScoreUpdate` へ統一し、各ウィンドウで同じ更新経路を通ることを確認する。
+
+- クリック時に `updateTermScore` が呼ばれること
+- ピン留め単語は `useScoreUpdate` 内でスコア更新をスキップすること
+- Step4時点では `termClickWeights` を残したまま共存できること
+
+## テスト項目
+
+| # | テストケース | 種別 | 期待結果 |
+|---|---|---|---|
+| 1 | `useScoreUpdate` の導入 | 実装確認 | 3ウィンドウが共通フック経由でスコア更新する |
+| 2 | BubbleCloudWindow クリック挙動 | 実装確認 | 既存の `incrementClickWeight` と `onScoreClick` が両方動く |
+| 3 | ImportanceRankingWindow / TranscriptionWindow | 実装確認 | 選択・履歴追加に加えて `onScoreClick` が呼ばれる |
+| 4 | 回帰テスト | 単体 | termStore / adapters / transcription mode の既存テスト成功 |
+
+## 実行結果
+
+### 実行コマンド
+
+```bash
+cd Frontend
+bun test src/stores/__tests__/termStore.test.ts src/infrastructure/adapters src/presentation/hooks/__tests__/transcriptionModeSync.test.ts
+bun run build
+```
+
+| コマンド | 結果 | メモ |
+|----------|------|------|
+| `bun test ...` | 合格 | 23件成功、0件失敗 |
+| `bun run build` | 合格 | `tsc -b && vite build` 成功 |

--- a/Frontend/docs/tests/test-spec-013.md
+++ b/Frontend/docs/tests/test-spec-013.md
@@ -18,6 +18,7 @@
 - クリック時に `updateTermScore` が呼ばれること
 - ピン留め単語は `useScoreUpdate` 内でスコア更新をスキップすること
 - Step4時点では `termClickWeights` を残したまま共存できること
+- 文字起こし/重要度ウィンドウでクリックした場合も `incrementClickWeight` が反映されること
 
 ## テスト項目
 
@@ -25,8 +26,9 @@
 |---|---|---|---|
 | 1 | `useScoreUpdate` の導入 | 実装確認 | 3ウィンドウが共通フック経由でスコア更新する |
 | 2 | BubbleCloudWindow クリック挙動 | 実装確認 | 既存の `incrementClickWeight` と `onScoreClick` が両方動く |
-| 3 | ImportanceRankingWindow / TranscriptionWindow | 実装確認 | 選択・履歴追加に加えて `onScoreClick` が呼ばれる |
-| 4 | 回帰テスト | 単体 | termStore / adapters / transcription mode の既存テスト成功 |
+| 3 | ImportanceRankingWindow / TranscriptionWindow | 実装確認 | `onScoreClick` と `incrementClickWeight` の両方が呼ばれる |
+| 4 | バブルとの双方向同期 | 実装確認 | どのウィンドウでクリックしてもバブルサイズとランキングが更新される |
+| 5 | 回帰テスト | 単体 | termStore / adapters / transcription mode の既存テスト成功 |
 
 ## 実行結果
 

--- a/Frontend/src/presentation/hooks/useScoreUpdate.ts
+++ b/Frontend/src/presentation/hooks/useScoreUpdate.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react'
+import { defaultScoreUpdateStrategy } from '../../infrastructure/adapters/DefaultScoreUpdateStrategy'
+import { useTermStore } from '../../stores/termStore'
+
+export function useScoreUpdate() {
+  const onClick = useCallback((termId: string) => {
+    const store = useTermStore.getState()
+    const term = store.activeTerms.find((activeTerm) => activeTerm.id === termId)
+    if (!term) return
+    if (store.pinnedTermIds.has(termId)) return
+    const newScore = defaultScoreUpdateStrategy.onClick(term.score)
+    store.updateTermScore(termId, newScore)
+  }, [])
+
+  return { onClick }
+}

--- a/Frontend/src/presentation/windows/BubbleCloudWindow/index.tsx
+++ b/Frontend/src/presentation/windows/BubbleCloudWindow/index.tsx
@@ -5,6 +5,7 @@ import { useTranscriptStore } from '../../../stores/transcriptStore'
 import { countTermFrequencies } from '../../../app/utils/termDetection'
 import type { WindowProps } from '../IWindowDefinition'
 import type { Term } from '../../../domain/entities/Term'
+import { useScoreUpdate } from '../../hooks/useScoreUpdate'
 
 export const BubbleCloudWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const transcript = useTranscriptStore(s => s.transcript)
@@ -19,11 +20,13 @@ export const BubbleCloudWindow: React.FC<WindowProps> = ({ darkMode = true }) =>
   const addToHistory = useTermStore(s => s.addToHistory)
   const incrementClickWeight = useTermStore(s => s.incrementClickWeight)
   const togglePin = useTermStore(s => s.togglePin)
+  const { onClick: onScoreClick } = useScoreUpdate()
 
   const handleTermClick = (term: Term) => {
     selectTerm(term)
     addToHistory(term)
     incrementClickWeight(term.id)
+    onScoreClick(term.id)
   }
 
   return (

--- a/Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx
+++ b/Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx
@@ -32,6 +32,7 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
   const termClickWeights = useTermStore(s => s.termClickWeights)
   const selectTerm = useTermStore(s => s.selectTerm)
   const addToHistory = useTermStore(s => s.addToHistory)
+  const incrementClickWeight = useTermStore(s => s.incrementClickWeight)
   const pinnedTermIds = useTermStore(s => s.pinnedTermIds)
   const togglePin = useTermStore(s => s.togglePin)
   const { onClick: onScoreClick } = useScoreUpdate()
@@ -84,6 +85,7 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
   const onTermClick = (term: Term) => {
     selectTerm(term)
     addToHistory(term)
+    incrementClickWeight(term.id)
     onScoreClick(term.id)
   }
 

--- a/Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx
+++ b/Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx
@@ -15,6 +15,7 @@ import { scaledContentFontPx } from '../../../app/utils/contentFontScale'
 import { useAccentTheme } from '../../../theme/AccentThemeContext'
 import { accentRgba, accentRgbSolid } from '../../../theme/accentStyles'
 import { useImportanceRankingWindowSettingsStore } from '../../../stores/importanceRankingWindowSettingsStore'
+import { useScoreUpdate } from '../../hooks/useScoreUpdate'
 
 const RANK_THROTTLE_MS = 160
 const BASE_ROW_HEIGHT = 66
@@ -33,6 +34,7 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
   const addToHistory = useTermStore(s => s.addToHistory)
   const pinnedTermIds = useTermStore(s => s.pinnedTermIds)
   const togglePin = useTermStore(s => s.togglePin)
+  const { onClick: onScoreClick } = useScoreUpdate()
 
   const contentFontScale = useContentFontScaleStore(s => s.scale)
   const masterSizeScale = useImportanceRankingWindowSettingsStore(s => s.masterSizeScale)
@@ -82,6 +84,7 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
   const onTermClick = (term: Term) => {
     selectTerm(term)
     addToHistory(term)
+    onScoreClick(term.id)
   }
 
   const onTermContextMenu = (event: React.MouseEvent, termId: string) => {

--- a/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
+++ b/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
@@ -12,6 +12,7 @@ export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) 
   const { transcript, isListening } = useTranscription()
   const selectTerm = useTermStore(s => s.selectTerm)
   const addToHistory = useTermStore(s => s.addToHistory)
+  const incrementClickWeight = useTermStore(s => s.incrementClickWeight)
   const togglePin = useTermStore(s => s.togglePin)
   const isPinned = useTermStore(s => s.pinnedTermIds)
   const activeTerms = useTermStore(s => s.activeTerms)
@@ -26,6 +27,7 @@ export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) 
       onTermClick={(term: Term) => {
         selectTerm(term)
         addToHistory(term)
+        incrementClickWeight(term.id)
         onScoreClick(term.id)
       }}
       onTermHover={() => {}}

--- a/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
+++ b/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
@@ -5,14 +5,17 @@ import { useDemoTools } from '../../context/DemoToolsContext'
 import { useTermStore } from '../../../stores/termStore'
 import type { WindowProps } from '../IWindowDefinition'
 import type { Term } from '../../../domain/entities/Term'
+import { useScoreUpdate } from '../../hooks/useScoreUpdate'
 
 export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const demoStream = useDemoTools()
   const { transcript, isListening } = useTranscription()
   const selectTerm = useTermStore(s => s.selectTerm)
+  const addToHistory = useTermStore(s => s.addToHistory)
   const togglePin = useTermStore(s => s.togglePin)
   const isPinned = useTermStore(s => s.pinnedTermIds)
   const activeTerms = useTermStore(s => s.activeTerms)
+  const { onClick: onScoreClick } = useScoreUpdate()
 
   return (
     <TranscriptionView
@@ -20,7 +23,11 @@ export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) 
       isListening={isListening}
       showRecordingCluster={false}
       showEmbeddedResetButton={false}
-      onTermClick={(term: Term) => selectTerm(term)}
+      onTermClick={(term: Term) => {
+        selectTerm(term)
+        addToHistory(term)
+        onScoreClick(term.id)
+      }}
       onTermHover={() => {}}
       isPinned={isPinned}
       onTogglePin={togglePin}


### PR DESCRIPTION
## Summary
- `useScoreUpdate` フックを追加し、クリック時の `updateTermScore` 経路を共通化
- `BubbleCloudWindow` / `ImportanceRankingWindow` / `TranscriptionWindow` の単語クリック処理に `useScoreUpdate` を適用
- Step4時点の要件どおり `termClickWeights` は維持し、文字起こし/ランキング側クリックでも `incrementClickWeight` を反映してバブル・ランキングの更新を双方向同期
- `order-003` と `test-spec-013` を更新してStep4の検証結果を記録

## Test plan
- [x] `cd Frontend && bun test src/stores/__tests__/termStore.test.ts src/infrastructure/adapters src/presentation/hooks/__tests__/transcriptionModeSync.test.ts`
- [x] `cd Frontend && bun run build`

Made with [Cursor](https://cursor.com)