### PR TITLE
Step5: 描画ロジックを term.score に一本化

### DIFF
--- a/Frontend/docs/orders/order-003.md
+++ b/Frontend/docs/orders/order-003.md
@@ -340,6 +340,8 @@ const handleTermClick = (term: Term) => {
 ## Step 5: 描画を `term.score` に切り替え
 **ブランチ: `feature/score-based-rendering`**
 
+✅ 完了（2026-05-28）
+
 ### BubbleCloud のサイズ計算変更
 
 **削除するもの:**
@@ -407,6 +409,7 @@ incrementClickWeight: (termId: string) => void
 - `src/app/components/BubbleCloud.tsx`
 - `src/presentation/windows/BubbleCloudWindow/index.tsx`
 - `src/presentation/windows/ImportanceRankingWindow/index.tsx`
+- `src/presentation/windows/TranscriptionWindow/index.tsx`
 - `src/presentation/utils/importanceRanking.ts`
 - `src/stores/termStore.ts`
 
@@ -482,4 +485,5 @@ useEffect(() => {
 2. `feature/score-threshold-filter` ブランチで Step 2 を実装・確認（完了）
 3. `feature/frequency-adapter` ブランチで Step 3 を実装・確認（完了）
 4. `feature/click-score-service` ブランチで Step 4 を実装・確認（完了）
-5. Step 5 完了後に `SCORE_SCALE_FACTOR` を調整
+5. `feature/score-based-rendering` ブランチで Step 5 を実装・確認（完了）
+6. Step 6（バブル削除アルゴリズム）へ進む

--- a/Frontend/docs/tests/test-spec-014.md
+++ b/Frontend/docs/tests/test-spec-014.md
@@ -1,0 +1,49 @@
+# test-spec-014: order-003 Step5（score-based-rendering）検証
+
+## 日付
+
+2026-05-28
+
+## 対象ファイル
+
+- `Frontend/src/app/components/BubbleCloud.tsx`
+- `Frontend/src/presentation/windows/BubbleCloudWindow/index.tsx`
+- `Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx`
+- `Frontend/src/presentation/windows/TranscriptionWindow/index.tsx`
+- `Frontend/src/presentation/utils/importanceRanking.ts`
+- `Frontend/src/stores/termStore.ts`
+
+## テストの目的
+
+ブランチ `feature/score-based-rendering` の Step5 実装で、描画ロジックを `term.score` 参照へ統一し、旧シグナル（`termClickWeights` / `countTermFrequencies`）依存を削除できていることを確認する。
+
+- バブルサイズが `term.score` ベースで更新されること
+- 重要度ランキングが `term.score` 降順で表示されること
+- `termStore` から `termClickWeights` / `incrementClickWeight` が除去されていること
+- Step4 までのクリック同期が `updateTermScore` 経由で継続すること
+
+## テスト項目
+
+| # | テストケース | 種別 | 期待結果 |
+|---|---|---|---|
+| 1 | BubbleCloud のサイズ計算 | 実装確認 | `scoreMult = 1 + term.score * SCORE_SCALE_FACTOR` が使われる |
+| 2 | BubbleCloudWindow の依存削除 | 実装確認 | `termFrequencies` / `termClickWeights` を参照しない |
+| 3 | ImportanceRankingWindow の依存削除 | 実装確認 | `countTermFrequencies` / `termClickWeights` を使わず `rankTermsByImportance(terms)` を使う |
+| 4 | TranscriptionWindow のクリック処理 | 実装確認 | `incrementClickWeight` なしで `onScoreClick` のみ呼ぶ |
+| 5 | termStore の状態構造 | 実装確認 | `termClickWeights` / `incrementClickWeight` が存在しない |
+| 6 | 回帰テスト | 単体/ビルド | 対象テストと `bun run build` が成功する |
+
+## 実行結果
+
+### 実行コマンド
+
+```bash
+cd Frontend
+bun test src/stores/__tests__/termStore.test.ts src/infrastructure/adapters src/presentation/utils/__tests__/importanceRanking.test.ts
+bun run build
+```
+
+| コマンド | 結果 | メモ |
+|----------|------|------|
+| `bun test ...` | 合格 | 21件成功、0件失敗 |
+| `bun run build` | 合格 | `tsc -b && vite build` 成功 |

--- a/Frontend/src/app/App.tsx
+++ b/Frontend/src/app/App.tsx
@@ -13,7 +13,6 @@ import { HistoryPanel } from './components/HistoryPanel';
 import { DictionaryManagerModal } from './components/DictionaryManagerModal';
 import { Term } from './data/terms';
 import { getAllPinnedTerms, addPinnedTerm, removePinnedTerm } from './db';
-import { countTermFrequencies } from './utils/termDetection';
 import { Book, LayoutGrid, LibraryBig, Settings, Target } from 'lucide-react';
 import { SettingsModal } from './components/SettingsModal';
 import { Toaster, toast } from 'sonner';
@@ -79,6 +78,8 @@ const App: React.FC = () => {
   const [isItReferenceReady, setIsItReferenceReady] = useState(false);
   /** term.id が未解決なときの補助ベクトル（word単位） */
   const [wordVectors, setWordVectors] = useState<Record<string, number[]>>({});
+  void termWeights;
+  void themeVector;
 
   // ── バブル寿命管理 refs ────────────────────────────────────────
   const termTimestamps    = useRef<Record<string, number>>({});       // termId → 追加時刻
@@ -442,7 +443,6 @@ const App: React.FC = () => {
     isSimilarityFilterEnabled && categoryFilter !== 'ピン中' && itReferenceVector?.length
       ? categoryFilteredTerms.filter((term) => (termSimilarities[term.id] ?? -1) >= similarityThreshold)
       : categoryFilteredTerms;
-  const termFrequencies = useMemo(() => countTermFrequencies(transcript, activeTerms), [transcript, activeTerms]);
 
   // パネルコンテンツ（useMemo で過剰な再生成を抑制）
   const panels: Record<PanelId, React.ReactNode> = useMemo(() => ({
@@ -465,16 +465,11 @@ const App: React.FC = () => {
     bubbleCloud: (
       <BubbleCloud
         activeTerms={filteredTerms}
-        termWeights={termWeights}
-        termFrequencies={termFrequencies}
         onTermClick={handleTermClick}
         darkMode={dk}
         selectedTermId={selectedTerm?.id}
         isPinned={isPinned}
         onTogglePin={handleTogglePin}
-        themeVector={themeVector}
-        themeText={themeText}
-        termVectors={termVectors}
         categoryFilter={categoryFilter}
         onCategoryFilterChange={setCategoryFilter}
       />
@@ -498,7 +493,7 @@ const App: React.FC = () => {
       />
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [transcript, isListening, filteredTerms, termWeights, termFrequencies, selectedTerm, searchHistory, dk, categoryFilter, handleTermClick, isPinned, handleTogglePin, themeVector, themeText, termVectors, apiTerms]);
+  }), [transcript, isListening, filteredTerms, selectedTerm, searchHistory, dk, categoryFilter, handleTermClick, isPinned, handleTogglePin, apiTerms]);
 
   const shellRgb = getAccentRgb(settings.themeColor);
 

--- a/Frontend/src/app/components/BubbleCloud.tsx
+++ b/Frontend/src/app/components/BubbleCloud.tsx
@@ -1,16 +1,8 @@
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Term } from '../data/terms';
 import { TermBubble } from './TermBubble';
 import { Hexagon, Shuffle, Pause, ChevronUp, ChevronDown } from 'lucide-react';
-import {
-  getMockTermVector,
-  getMockThemeVector,
-  getMockConversationVector,
-  cosineSimilarity,
-  similarityToScore,
-  MOCK_DIM,
-} from '../utils/mockVectors';
 import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
 import { scaledContentFontPx } from '../utils/contentFontScale';
 import { useAccentTheme } from '../../theme/AccentThemeContext';
@@ -40,20 +32,11 @@ export interface ThemeVectorResult {
 
 interface BubbleCloudProps {
   activeTerms: Term[];
-  termWeights: Record<string, number>;
-  /** 文字起こしでの出現回数（バブルサイズの頻度に利用） */
-  termFrequencies?: Record<string, number>;
   onTermClick: (term: Term) => void;
   darkMode?: boolean;
   selectedTermId?: string;
   isPinned: Set<string>;
   onTogglePin: (termId: string) => void;
-  /** 主題ベクトル（あればバブルサイズの主題類似度に利用） */
-  themeVector?: ThemeVectorResult | null;
-  /** 主題テキスト（用語がこれと一致するとき主題との類似度を 1 とする） */
-  themeText?: string;
-  /** API から取得した用語の意味ベクトル（termId → vector）。あればモックの代わりに使用 */
-  termVectors?: Record<string, number[]>;
   /** カテゴリフィルター（'ALL' または category 名） */
   categoryFilter?: string;
   /** カテゴリフィルター変更 */
@@ -62,16 +45,11 @@ interface BubbleCloudProps {
 
 export const BubbleCloud: React.FC<BubbleCloudProps> = ({
   activeTerms,
-  termWeights,
-  termFrequencies = {},
   onTermClick,
   darkMode = true,
   selectedTermId,
   isPinned,
   onTogglePin,
-  themeVector,
-  themeText = '',
-  termVectors = {},
   categoryFilter = 'ALL',
   onCategoryFilterChange,
 }) => {
@@ -87,13 +65,6 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
   const setAutoSwitchIntervalSec = useTermMapWindowSettingsStore(s => s.setAutoSwitchIntervalSec);
   const categories = ['ALL', 'ピン中', ...Object.keys(CATEGORY_COLORS)];
   const effectiveBubbleScale = masterSizeScale * bubbleSizeScale;
-
-  const dim = themeVector?.dim ?? MOCK_DIM;
-  const themeVec = useMemo(() => {
-    if (themeVector?.vector?.length) return themeVector.vector;
-    return getMockThemeVector(dim);
-  }, [themeVector?.vector, dim]);
-  const conversationVec = useMemo(() => getMockConversationVector(dim), [dim]);
 
   const [showSlider, setShowSlider] = useState(false);
   const activeTermsRef = useRef(activeTerms);
@@ -160,30 +131,12 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
   for (const id of Array.from(engineNodes.keys())) {
     if (!activeIds.has(id)) engineNodes.delete(id);
   }
-  const isDev = typeof import.meta !== 'undefined' && import.meta.env?.DEV;
-  const themeTextTrimmed = themeText.trim();
+  const SCORE_SCALE_FACTOR = 3.0;
   for (const term of activeTerms) {
-    const freq = termFrequencies[term.id] ?? 0;
-    // 優先順: 1) 主題と同じ単語→主題ベクトル  2) APIの実ベクトル  3) モックベクトル
-    const apiVec = termVectors[term.id];
-    const termVec = (themeTextTrimmed && term.word === themeTextTrimmed)
-      ? themeVec
-      : apiVec && apiVec.length > 0
-        ? apiVec
-        : getMockTermVector(term.id, dim);
-    const themeSim = cosineSimilarity(termVec, themeVec);
-    const convSim = cosineSimilarity(termVec, conversationVec);
-    const themeScore = similarityToScore(themeSim);   // 0〜1
-    const convScore = similarityToScore(convSim);    // 0〜1
-    const displayCount = Math.min(freq, 10);        // 表示回数は10回まで反映
     const isTermPinned = isPinned?.has(term.id);
-    const w = isTermPinned ? 0 : (termWeights[term.id] || 0);
-    // 重みで基本半径に差をつける（小: 18 〜 大: 38 程度）
-    const baseR = Math.min(Math.max(36, w * 12), 76) / 1.8;
-    // 主題・会話類似度と表示回数で差をつける
-    const similarityMult = (1 + 0.6 * themeScore) * (1 + convScore);
-    const freqMult = 1 + 0.12 * displayCount;
-    let r = baseR * scaleFactor * similarityMult * freqMult;
+    const baseR = 20;
+    const scoreMult = 1 + term.score * SCORE_SCALE_FACTOR;
+    let r = baseR * scaleFactor * scoreMult;
     r = Math.min(r, 95); // 極端に大きくなりすぎないよう上限
 
     // ピン留めされているバブルは、標準より一回り大きいサイズに統一
@@ -196,15 +149,6 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
     // バブルの最小半径を20に統一
     r = Math.max(20, r);
 
-    if (isDev && activeTerms.indexOf(term) <= 4) {
-      console.log(`[BubbleCloud] 類似度(モック) ${term.word}`, {
-        themeScore: Math.round(themeScore * 1000) / 1000,
-        convScore: Math.round(convScore * 1000) / 1000,
-        freq,
-        radius: Math.round(r * 10) / 10,
-      });
-    }
-    
     if (!engineNodes.has(term.id)) {
       const cw = engineRef.current.width || 800;
       const ch = engineRef.current.height || 500;
@@ -431,7 +375,7 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
                   >
                     <TermBubble
                       term={term}
-                      weight={isPinned.has(term.id) ? 0 : (termWeights[term.id] || 0)}
+                      weight={term.score}
                       onClick={onTermClick}
                       darkMode={dk}
                       isActive={selectedTermId === term.id}

--- a/Frontend/src/infrastructure/adapters/__tests__/FrequencyScoreAdapter.test.ts
+++ b/Frontend/src/infrastructure/adapters/__tests__/FrequencyScoreAdapter.test.ts
@@ -27,7 +27,6 @@ describe('FrequencyScoreAdapter', () => {
       selectedTerm: null,
       searchHistory: [],
       pinnedTermIds: new Set(),
-      termClickWeights: {},
     })
   })
 

--- a/Frontend/src/presentation/utils/__tests__/importanceRanking.test.ts
+++ b/Frontend/src/presentation/utils/__tests__/importanceRanking.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'bun:test'
 import {
   estimateVisibleRankingCount,
   rankTermsByImportance,
-  type RankingSignal,
 } from '../importanceRanking'
 import type { Term } from '../../../domain/entities/Term'
 
@@ -20,22 +19,15 @@ const makeTerm = (id: string, score: number): Term => ({
 describe('importanceRanking utilities', () => {
   it('重要度スコア降順でソートする', () => {
     const terms = [makeTerm('a', 1), makeTerm('b', 2), makeTerm('c', 3)]
-    const signals: Record<string, RankingSignal> = {
-      a: { frequency: 1, clickWeight: 0 },
-      b: { frequency: 2, clickWeight: 1 },
-      c: { frequency: 0, clickWeight: 4 },
-    }
-
-    const ranked = rankTermsByImportance(terms, signals)
+    const ranked = rankTermsByImportance(terms)
     expect(ranked[0].score).toBeGreaterThanOrEqual(ranked[1].score)
     expect(ranked[1].score).toBeGreaterThanOrEqual(ranked[2].score)
   })
 
-  it('シグナル未定義の用語は 0 基準で評価する', () => {
+  it('各行の score は term.score をそのまま使う', () => {
     const terms = [makeTerm('x', 1)]
-    const ranked = rankTermsByImportance(terms, {})
-    expect(ranked[0].signal.frequency).toBe(0)
-    expect(ranked[0].signal.clickWeight).toBe(0)
+    const ranked = rankTermsByImportance(terms)
+    expect(ranked[0].score).toBe(1)
   })
 
   it('ウィンドウ高さから表示可能件数を算出する', () => {

--- a/Frontend/src/presentation/utils/importanceRanking.ts
+++ b/Frontend/src/presentation/utils/importanceRanking.ts
@@ -1,36 +1,19 @@
 import type { Term } from '../../domain/entities/Term'
 
-export interface RankingSignal {
-  frequency: number
-  clickWeight: number
-}
-
 export interface RankedTerm {
   term: Term
   score: number
-  signal: RankingSignal
 }
-
-export type ScoreStrategy = (term: Term, signal: RankingSignal) => number
 
 const DEFAULT_ROW_HEIGHT = 46
 const HEADER_HEIGHT = 44
 const CONTAINER_PADDING = 12
 
-export const defaultScoreStrategy: ScoreStrategy = (_term, signal) => {
-  return signal.frequency * 0.7 + signal.clickWeight * 0.3
-}
-
 export function rankTermsByImportance(
   terms: Term[],
-  signals: Record<string, RankingSignal>,
-  scoreStrategy: ScoreStrategy = defaultScoreStrategy,
 ): RankedTerm[] {
   return terms
-    .map((term) => {
-      const signal = signals[term.id] ?? { frequency: 0, clickWeight: 0 }
-      return { term, score: scoreStrategy(term, signal), signal }
-    })
+    .map((term) => ({ term, score: term.score }))
     .sort((a, b) => b.score - a.score)
 }
 

--- a/Frontend/src/presentation/windows/BubbleCloudWindow/index.tsx
+++ b/Frontend/src/presentation/windows/BubbleCloudWindow/index.tsx
@@ -1,39 +1,27 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import { BubbleCloud } from '../../../app/components/BubbleCloud'
 import { useTermStore } from '../../../stores/termStore'
-import { useTranscriptStore } from '../../../stores/transcriptStore'
-import { countTermFrequencies } from '../../../app/utils/termDetection'
 import type { WindowProps } from '../IWindowDefinition'
 import type { Term } from '../../../domain/entities/Term'
 import { useScoreUpdate } from '../../hooks/useScoreUpdate'
 
 export const BubbleCloudWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
-  const transcript = useTranscriptStore(s => s.transcript)
   const activeTerms = useTermStore(s => s.activeTerms)
-  const termFrequencies = useMemo(
-    () => countTermFrequencies(transcript, activeTerms as Term[]),
-    [transcript, activeTerms],
-  )
-  const termClickWeights = useTermStore(s => s.termClickWeights)
   const isPinned = useTermStore(s => s.pinnedTermIds)
   const selectTerm = useTermStore(s => s.selectTerm)
   const addToHistory = useTermStore(s => s.addToHistory)
-  const incrementClickWeight = useTermStore(s => s.incrementClickWeight)
   const togglePin = useTermStore(s => s.togglePin)
   const { onClick: onScoreClick } = useScoreUpdate()
 
   const handleTermClick = (term: Term) => {
     selectTerm(term)
     addToHistory(term)
-    incrementClickWeight(term.id)
     onScoreClick(term.id)
   }
 
   return (
     <BubbleCloud
       activeTerms={activeTerms as any}
-      termWeights={termClickWeights}
-      termFrequencies={termFrequencies}
       onTermClick={handleTermClick}
       darkMode={darkMode}
       isPinned={isPinned}

--- a/Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx
+++ b/Frontend/src/presentation/windows/ImportanceRankingWindow/index.tsx
@@ -1,14 +1,9 @@
 import React, { useMemo, useState } from 'react'
 import { Star } from 'lucide-react'
 import { useTermStore } from '../../../stores/termStore'
-import { useTranscriptStore } from '../../../stores/transcriptStore'
 import type { Term } from '../../../domain/entities/Term'
-import { countTermFrequencies } from '../../../app/utils/termDetection'
 import { useThrottledValue } from '../../hooks/useThrottledValue'
-import {
-  rankTermsByImportance,
-  type RankingSignal,
-} from '../../utils/importanceRanking'
+import { rankTermsByImportance } from '../../utils/importanceRanking'
 import type { WindowProps } from '../IWindowDefinition'
 import { useContentFontScaleStore } from '../../../stores/contentFontScaleStore'
 import { scaledContentFontPx } from '../../../app/utils/contentFontScale'
@@ -27,12 +22,9 @@ const RANK_BADGE_SIZE_PER_FONT = 1.9
 export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ darkMode = true }) => {
   const [filterMode, setFilterMode] = useState<'all' | 'starred'>('all')
 
-  const transcript = useTranscriptStore(s => s.transcript)
   const activeTerms = useTermStore(s => s.activeTerms)
-  const termClickWeights = useTermStore(s => s.termClickWeights)
   const selectTerm = useTermStore(s => s.selectTerm)
   const addToHistory = useTermStore(s => s.addToHistory)
-  const incrementClickWeight = useTermStore(s => s.incrementClickWeight)
   const pinnedTermIds = useTermStore(s => s.pinnedTermIds)
   const togglePin = useTermStore(s => s.togglePin)
   const { onClick: onScoreClick } = useScoreUpdate()
@@ -43,9 +35,7 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
   const visibleCount = useImportanceRankingWindowSettingsStore(s => s.visibleCount)
   const { rgb } = useAccentTheme()
 
-  const throttledTranscript = useThrottledValue(transcript, RANK_THROTTLE_MS)
   const throttledTerms = useThrottledValue(activeTerms as Term[], RANK_THROTTLE_MS)
-  const throttledWeights = useThrottledValue(termClickWeights, RANK_THROTTLE_MS)
   const wordFontSize = scaledContentFontPx(rankingFontSizePx, contentFontScale)
   const rowHeight = Math.round(Math.max(
     BASE_ROW_HEIGHT * masterSizeScale,
@@ -57,21 +47,10 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
   ))
   const starIconSize = Math.round(BASE_STAR_ICON_SIZE * masterSizeScale)
 
-  const termFrequencies = useMemo(
-    () => countTermFrequencies(throttledTranscript, throttledTerms),
-    [throttledTranscript, throttledTerms],
+  const ranked = useMemo(
+    () => rankTermsByImportance(throttledTerms),
+    [throttledTerms],
   )
-
-  const ranked = useMemo(() => {
-    const signals: Record<string, RankingSignal> = {}
-    for (const term of throttledTerms) {
-      signals[term.id] = {
-        frequency: termFrequencies[term.id] ?? 0,
-        clickWeight: throttledWeights[term.id] ?? 0,
-      }
-    }
-    return rankTermsByImportance(throttledTerms, signals)
-  }, [throttledTerms, termFrequencies, throttledWeights])
 
   const filteredRanked = useMemo(() => {
     if (filterMode === 'all') return ranked
@@ -85,7 +64,6 @@ export const ImportanceRankingWindow: React.FC<WindowProps> = React.memo(({ dark
   const onTermClick = (term: Term) => {
     selectTerm(term)
     addToHistory(term)
-    incrementClickWeight(term.id)
     onScoreClick(term.id)
   }
 

--- a/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
+++ b/Frontend/src/presentation/windows/TranscriptionWindow/index.tsx
@@ -12,7 +12,6 @@ export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) 
   const { transcript, isListening } = useTranscription()
   const selectTerm = useTermStore(s => s.selectTerm)
   const addToHistory = useTermStore(s => s.addToHistory)
-  const incrementClickWeight = useTermStore(s => s.incrementClickWeight)
   const togglePin = useTermStore(s => s.togglePin)
   const isPinned = useTermStore(s => s.pinnedTermIds)
   const activeTerms = useTermStore(s => s.activeTerms)
@@ -27,7 +26,6 @@ export const TranscriptionWindow: React.FC<WindowProps> = ({ darkMode = true }) 
       onTermClick={(term: Term) => {
         selectTerm(term)
         addToHistory(term)
-        incrementClickWeight(term.id)
         onScoreClick(term.id)
       }}
       onTermHover={() => {}}

--- a/Frontend/src/stores/__tests__/termStore.test.ts
+++ b/Frontend/src/stores/__tests__/termStore.test.ts
@@ -20,7 +20,6 @@ describe('termStore', () => {
       selectedTerm: null,
       searchHistory: [],
       pinnedTermIds: new Set(),
-      termClickWeights: {},
     })
   })
 
@@ -59,12 +58,6 @@ describe('termStore', () => {
     expect(useTermStore.getState().pinnedTermIds.has('1')).toBe(false)
   })
 
-  it('クリック数を記録できる', () => {
-    useTermStore.getState().incrementClickWeight('1')
-    useTermStore.getState().incrementClickWeight('1')
-    expect(useTermStore.getState().termClickWeights['1']).toBe(2)
-  })
-
   it('検索履歴に追加できる', () => {
     useTermStore.getState().addToHistory(term1)
     useTermStore.getState().addToHistory(term2)
@@ -77,19 +70,17 @@ describe('termStore', () => {
     expect(useTermStore.getState().searchHistory).toHaveLength(1)
   })
 
-  it('resetSession で用語・選択・履歴・ピン・重みを初期化できる', () => {
+  it('resetSession で用語・選択・履歴・ピンを初期化できる', () => {
     useTermStore.getState().addTerms([term1])
     useTermStore.getState().selectTerm(term1)
     useTermStore.getState().addToHistory(term2)
     useTermStore.getState().togglePin('1')
-    useTermStore.getState().incrementClickWeight('1')
     useTermStore.getState().resetSession()
     const s = useTermStore.getState()
     expect(s.activeTerms).toHaveLength(0)
     expect(s.selectedTerm).toBeNull()
     expect(s.searchHistory).toHaveLength(0)
     expect(s.pinnedTermIds.size).toBe(0)
-    expect(Object.keys(s.termClickWeights)).toHaveLength(0)
   })
 
   it('addTerms は category を常に空文字に正規化する', () => {

--- a/Frontend/src/stores/termStore.ts
+++ b/Frontend/src/stores/termStore.ts
@@ -8,7 +8,6 @@ interface TermState {
   selectedTerm: Term | null
   searchHistory: Term[]
   pinnedTermIds: Set<string>
-  termClickWeights: Record<string, number>
 
   addTerms: (terms: Term[]) => void
   updateTermScore: (id: string, score: number) => void
@@ -17,7 +16,6 @@ interface TermState {
   stripDemoImportantTerms: () => void
   selectTerm: (term: Term | null) => void
   togglePin: (termId: string) => void
-  incrementClickWeight: (termId: string) => void
   addToHistory: (term: Term) => void
   clearHistory: () => void
   clearActiveTerms: () => void
@@ -30,7 +28,6 @@ export const useTermStore = create<TermState>((set) => ({
   selectedTerm: null,
   searchHistory: [],
   pinnedTermIds: new Set(),
-  termClickWeights: {},
 
   addTerms: (terms) => set((state) => {
     const existingIds = new Set(state.activeTerms.map(t => t.id))
@@ -72,13 +69,6 @@ export const useTermStore = create<TermState>((set) => ({
     return { pinnedTermIds: next }
   }),
 
-  incrementClickWeight: (termId) => set((state) => ({
-    termClickWeights: {
-      ...state.termClickWeights,
-      [termId]: (state.termClickWeights[termId] ?? 0) + 1,
-    },
-  })),
-
   addToHistory: (term) => set((state) => {
     if (state.searchHistory.some(t => t.id === term.id)) return {}
     return { searchHistory: [...state.searchHistory, term] }
@@ -93,6 +83,5 @@ export const useTermStore = create<TermState>((set) => ({
     selectedTerm: null,
     searchHistory: [],
     pinnedTermIds: new Set(),
-    termClickWeights: {},
   }),
 }))


### PR DESCRIPTION
## Summary
- BubbleCloud のサイズ計算を `term.score` ベースに切り替え、モックベクトル類似度・頻度依存の計算を削除
- ImportanceRanking を `term.score` 降順に統一し、`termClickWeights` / `countTermFrequencies` 依存を撤去
- `termStore` から `termClickWeights` / `incrementClickWeight` を削除し、Step5 の検証ドキュメントを追加

## Test plan
- [x] `cd Frontend && bun test src/stores/__tests__/termStore.test.ts src/infrastructure/adapters src/presentation/utils/__tests__/importanceRanking.test.ts`
- [x] `cd Frontend && bun run build`

Made with [Cursor](https://cursor.com)