### PR TITLE
Step6: バブル寿命管理と最大表示数設定を実装

### DIFF
--- a/Frontend/docs/orders/order-003.md
+++ b/Frontend/docs/orders/order-003.md
@@ -418,6 +418,8 @@ incrementClickWeight: (termId: string) => void
 ## Step 6: バブル削除アルゴリズム
 **ブランチ: `feature/bubble-lifecycle`**
 
+✅ 完了（2026-05-28）
+
 ### 仕様（旧 `app/App.tsx` から移植）
 
 - `activeTerms` が 20件以下: 削除なし
@@ -466,9 +468,10 @@ useEffect(() => {
 
 ### 変更ファイル
 
-- `src/stores/termStore.ts`（`termTimestamps` / `removeTermById` は既存）
+- `src/stores/termStore.ts`（`termTimestamps` 追加、削除系 action と同期）
 - `src/presentation/hooks/useBubbleLifecycle.ts`（新規）
 - `src/presentation/App.tsx`（フック呼び出し追加）
+- `src/stores/__tests__/termStore.test.ts`（timestamp 管理のテスト追加）
 
 ---
 
@@ -486,4 +489,4 @@ useEffect(() => {
 3. `feature/frequency-adapter` ブランチで Step 3 を実装・確認（完了）
 4. `feature/click-score-service` ブランチで Step 4 を実装・確認（完了）
 5. `feature/score-based-rendering` ブランチで Step 5 を実装・確認（完了）
-6. Step 6（バブル削除アルゴリズム）へ進む
+6. `feature/bubble-lifecycle` ブランチで Step 6 を実装・確認（完了）

--- a/Frontend/docs/orders/order-003.md
+++ b/Frontend/docs/orders/order-003.md
@@ -422,10 +422,12 @@ incrementClickWeight: (termId: string) => void
 
 ### 仕様（旧 `app/App.tsx` から移植）
 
-- `activeTerms` が 20件以下: 削除なし
-- 21〜30件: 古い順に「削除待機」入り。5秒経過したら削除
-- 31件以上: 最古のものを即時削除して 30件に収める
+- バブルウィンドウ設定 `maxVisibleTerms`（5〜30）を上限として利用
+- `activeTerms` が `softLimit`（`min(20, maxVisibleTerms)`）以下: 削除なし
+- `softLimit + 1`〜`maxVisibleTerms`: 古い順に「削除待機」入り。5秒経過したら削除
+- `maxVisibleTerms` 超過: 非スター語を最古から即時削除して上限に収める
 - 並び順の基準: `termTimestamps`（追加時刻）の昇順（古い = 先頭）
+- 表示枠がスター語で埋まっている場合は、SSE到着時も新規バブルを追加しない
 
 ### 実装場所
 
@@ -434,8 +436,9 @@ incrementClickWeight: (termId: string) => void
 // src/presentation/hooks/useBubbleLifecycle.ts（フック化推奨）
 ```
 
-`termTimestamps: Record<string, number>` を termStore に追加し、  
-`addTerms` 時に `Date.now()` を記録する。
+`termTimestamps: Record<string, number>` を termStore で管理し、  
+`addTerms` 時に `Date.now()` を記録する。  
+同時に `maxVisibleTerms` を参照し、新規追加数を上限に合わせて制御する。
 
 削除ループは `useBubbleLifecycle` フックで `setInterval(1000)` を回し、  
 `removeTermById` を呼ぶ形にする（1秒ごとに判定）。
@@ -472,6 +475,9 @@ useEffect(() => {
 - `src/presentation/hooks/useBubbleLifecycle.ts`（新規）
 - `src/presentation/App.tsx`（フック呼び出し追加）
 - `src/stores/__tests__/termStore.test.ts`（timestamp 管理のテスト追加）
+- `src/stores/termMapWindowSettingsStore.ts`（`maxVisibleTerms` 追加）
+- `src/app/components/BubbleCloud.tsx`（最大表示数スライダー追加）
+- `src/stores/__tests__/termMapWindowSettingsStore.test.ts`
 
 ---
 

--- a/Frontend/docs/tests/test-spec-015.md
+++ b/Frontend/docs/tests/test-spec-015.md
@@ -1,0 +1,47 @@
+# test-spec-015: order-003 Step6（bubble-lifecycle）検証
+
+## 日付
+
+2026-05-28
+
+## 対象ファイル
+
+- `Frontend/src/presentation/hooks/useBubbleLifecycle.ts`
+- `Frontend/src/presentation/App.tsx`
+- `Frontend/src/stores/termStore.ts`
+- `Frontend/src/stores/__tests__/termStore.test.ts`
+
+## テストの目的
+
+ブランチ `feature/bubble-lifecycle` の Step6 実装で、バブル削除アルゴリズム（20〜30件のライフタイム管理）が `presentation` 側の共通フックとして動作し、`termStore` の `termTimestamps` と整合して管理されることを確認する。
+
+- 20件以下では削除が発生しない前提の状態管理が維持されること
+- 21〜30件の削除候補管理に必要な追加時刻（`termTimestamps`）が保存・削除と同期すること
+- 31件以上での即時削除に必要な `removeTermById` 経路が使えること
+- リセット時に `termTimestamps` が確実にクリアされること
+
+## テスト項目
+
+| # | テストケース | 種別 | 期待結果 |
+|---|---|---|---|
+| 1 | `termStore.addTerms` | 単体 | 追加された用語IDに `termTimestamps` が記録される |
+| 2 | `termStore.removeTermById` | 単体 | 用語削除時に対応する timestamp も削除される |
+| 3 | `termStore.clearActiveTerms` | 単体 | `activeTerms` と `termTimestamps` を同時にクリアする |
+| 4 | `termStore.resetSession` | 単体 | `termTimestamps` を含むセッション状態を初期化する |
+| 5 | `useBubbleLifecycle` の組み込み | 実装確認 | `presentation/App.tsx` で1回だけフックがマウントされる |
+| 6 | 回帰テスト | 単体/ビルド | 既存 adapters / ranking / transcription mode を含めて成功する |
+
+## 実行結果
+
+### 実行コマンド
+
+```bash
+cd Frontend
+bun test src/stores/__tests__/termStore.test.ts src/infrastructure/adapters src/presentation/utils/__tests__/importanceRanking.test.ts src/presentation/hooks/__tests__/transcriptionModeSync.test.ts
+bun run build
+```
+
+| コマンド | 結果 | メモ |
+|----------|------|------|
+| `bun test ...` | 合格 | 27件成功、0件失敗 |
+| `bun run build` | 合格 | `tsc -b && vite build` 成功 |

--- a/Frontend/docs/tests/test-spec-015.md
+++ b/Frontend/docs/tests/test-spec-015.md
@@ -10,6 +10,9 @@
 - `Frontend/src/presentation/App.tsx`
 - `Frontend/src/stores/termStore.ts`
 - `Frontend/src/stores/__tests__/termStore.test.ts`
+- `Frontend/src/stores/termMapWindowSettingsStore.ts`
+- `Frontend/src/app/components/BubbleCloud.tsx`
+- `Frontend/src/stores/__tests__/termMapWindowSettingsStore.test.ts`
 
 ## テストの目的
 
@@ -19,6 +22,8 @@
 - 21〜30件の削除候補管理に必要な追加時刻（`termTimestamps`）が保存・削除と同期すること
 - 31件以上での即時削除に必要な `removeTermById` 経路が使えること
 - リセット時に `termTimestamps` が確実にクリアされること
+- バブルウィンドウ内で `maxVisibleTerms`（5〜30）を設定できること
+- 表示枠がスター語で埋まっている場合に新規バブルが追加されないこと
 
 ## テスト項目
 
@@ -29,7 +34,10 @@
 | 3 | `termStore.clearActiveTerms` | 単体 | `activeTerms` と `termTimestamps` を同時にクリアする |
 | 4 | `termStore.resetSession` | 単体 | `termTimestamps` を含むセッション状態を初期化する |
 | 5 | `useBubbleLifecycle` の組み込み | 実装確認 | `presentation/App.tsx` で1回だけフックがマウントされる |
-| 6 | 回帰テスト | 単体/ビルド | 既存 adapters / ranking / transcription mode を含めて成功する |
+| 6 | `maxVisibleTerms` スライダー | 実装確認 | バブル設定から5〜30の範囲で上限を変更できる |
+| 7 | `termStore.addTerms` 上限制御 | 単体 | 上限到達時は新規追加を抑制する |
+| 8 | スター枠満了時の追加抑制 | 単体 | 全表示枠がスターの場合、新規語を追加しない |
+| 9 | 回帰テスト | 単体/ビルド | 既存 adapters / ranking / transcription mode を含めて成功する |
 
 ## 実行結果
 
@@ -37,11 +45,11 @@
 
 ```bash
 cd Frontend
-bun test src/stores/__tests__/termStore.test.ts src/infrastructure/adapters src/presentation/utils/__tests__/importanceRanking.test.ts src/presentation/hooks/__tests__/transcriptionModeSync.test.ts
+bun test src/stores/__tests__/termMapWindowSettingsStore.test.ts src/stores/__tests__/termStore.test.ts src/infrastructure/adapters src/presentation/utils/__tests__/importanceRanking.test.ts src/presentation/hooks/__tests__/transcriptionModeSync.test.ts
 bun run build
 ```
 
 | コマンド | 結果 | メモ |
 |----------|------|------|
-| `bun test ...` | 合格 | 27件成功、0件失敗 |
+| `bun test ...` | 合格 | 33件成功、0件失敗 |
 | `bun run build` | 合格 | `tsc -b && vite build` 成功 |

--- a/Frontend/src/app/components/BubbleCloud.tsx
+++ b/Frontend/src/app/components/BubbleCloud.tsx
@@ -10,6 +10,8 @@ import { accentRgba, accentSliderStyle, micStartButtonStyle, termChipStyle } fro
 import {
   TERM_MAP_AUTO_SWITCH_INTERVAL_MAX,
   TERM_MAP_AUTO_SWITCH_INTERVAL_MIN,
+  TERM_MAP_MAX_VISIBLE_TERMS_MAX,
+  TERM_MAP_MAX_VISIBLE_TERMS_MIN,
   useTermMapWindowSettingsStore,
 } from '../../stores/termMapWindowSettingsStore';
 
@@ -61,8 +63,10 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
   const textFontSizePx = useTermMapWindowSettingsStore(s => s.textFontSizePx);
   const isAutoPlay = useTermMapWindowSettingsStore(s => s.autoSwitchEnabled);
   const intervalSec = useTermMapWindowSettingsStore(s => s.autoSwitchIntervalSec);
+  const maxVisibleTerms = useTermMapWindowSettingsStore(s => s.maxVisibleTerms);
   const setAutoSwitchEnabled = useTermMapWindowSettingsStore(s => s.setAutoSwitchEnabled);
   const setAutoSwitchIntervalSec = useTermMapWindowSettingsStore(s => s.setAutoSwitchIntervalSec);
+  const setMaxVisibleTerms = useTermMapWindowSettingsStore(s => s.setMaxVisibleTerms);
   const categories = ['ALL', 'ピン中', ...Object.keys(CATEGORY_COLORS)];
   const effectiveBubbleScale = masterSizeScale * bubbleSizeScale;
 
@@ -265,7 +269,9 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
           </select>
         )}
         <span className={`ml-auto text-[10px] font-mono border px-1.5 py-0.5 rounded shrink-0 ${dk ? 'bg-slate-800/50 border-slate-700/50 text-slate-500' : 'bg-slate-100 border-slate-200 text-slate-400'}`}>
-          {categoryFilter === 'ピン中' ? `${activeTerms.length} ピン` : `${activeTerms.length} terms`}
+          {categoryFilter === 'ピン中'
+            ? `${activeTerms.length} ピン`
+            : `${activeTerms.length}/${maxVisibleTerms} terms`}
         </span>
       </div>
       {/* ピン中: IndexedDB のピン留め一覧を表で表示（文字起こしハイライト風） */}
@@ -473,6 +479,34 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
                   >
                     <ChevronUp size={14} className="mx-auto" />
                   </button>
+                </div>
+
+                <div className={`h-px ${dk ? 'bg-slate-700/70' : 'bg-slate-200'}`} />
+
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-black">最大表示数</span>
+                  <span className={`text-lg font-black tabular-nums ${dk ? 'text-slate-300' : 'text-slate-600'}`}>
+                    {maxVisibleTerms}<span className="text-xs font-bold ml-0.5">語</span>
+                  </span>
+                </div>
+                <div className="relative flex items-center">
+                  <input
+                    type="range"
+                    min={TERM_MAP_MAX_VISIBLE_TERMS_MIN}
+                    max={TERM_MAP_MAX_VISIBLE_TERMS_MAX}
+                    step={1}
+                    value={maxVisibleTerms}
+                    onChange={e => setMaxVisibleTerms(Number(e.target.value))}
+                    className="w-full h-2.5 rounded-full appearance-none cursor-pointer"
+                    style={{
+                      background: dk ? '#1e293b' : '#e2e8f0',
+                      ...accentSliderStyle(rgb),
+                    }}
+                  />
+                </div>
+                <div className={`flex justify-between text-[9px] font-bold -mt-1 ${dk ? 'text-slate-600' : 'text-slate-400'}`}>
+                  <span>少({TERM_MAP_MAX_VISIBLE_TERMS_MIN})</span>
+                  <span>多({TERM_MAP_MAX_VISIBLE_TERMS_MAX})</span>
                 </div>
               </motion.div>
             )}

--- a/Frontend/src/presentation/App.tsx
+++ b/Frontend/src/presentation/App.tsx
@@ -19,6 +19,7 @@ import { getOppositeThemeColor } from './utils/oppositeThemeColor'
 import { AccentThemeProvider } from '../theme/AccentThemeContext'
 import { DEFAULT_SCORE_THRESHOLD } from '../infrastructure/adapters/ScoreThresholdFilter'
 import { usePipelineDebugStore } from '../stores/pipelineDebugStore'
+import { useBubbleLifecycle } from './hooks/useBubbleLifecycle'
 
 // ウィンドウを一度だけ登録
 let _registered = false
@@ -37,6 +38,7 @@ const App: React.FC = () => {
   const [appearanceOpen, setAppearanceOpen] = useState(false)
   const [appearance, setAppearance] = useState({ darkMode: true, themeColor: 'indigo' })
   const [scoreThreshold, setScoreThreshold] = useState(DEFAULT_SCORE_THRESHOLD)
+  useBubbleLifecycle()
 
   const demoStream = useDemoStream({
     onAppend: text => getTranscriptionService().setTranscriptExternal(text),

--- a/Frontend/src/presentation/hooks/useBubbleLifecycle.ts
+++ b/Frontend/src/presentation/hooks/useBubbleLifecycle.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react'
+import { useTermStore } from '../../stores/termStore'
+
+export const SOFT_LIMIT = 20
+export const HARD_LIMIT = 30
+export const DEATH_ROW_MS = 5000
+
+export function useBubbleLifecycle() {
+  const deathRowRef = useRef<Record<string, number>>({})
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      const { activeTerms, termTimestamps, removeTermById } = useTermStore.getState()
+      const deathRow = deathRowRef.current
+      const now = Date.now()
+
+      if (activeTerms.length <= SOFT_LIMIT) {
+        deathRowRef.current = {}
+        return
+      }
+
+      const sorted = [...activeTerms].sort(
+        (a, b) => (termTimestamps[a.id] ?? 0) - (termTimestamps[b.id] ?? 0),
+      )
+
+      if (sorted.length > HARD_LIMIT) {
+        const overflowCount = sorted.length - HARD_LIMIT
+        const overflowTerms = sorted.splice(0, overflowCount)
+        overflowTerms.forEach((term) => {
+          removeTermById(term.id)
+          delete deathRow[term.id]
+        })
+      }
+
+      if (sorted.length <= SOFT_LIMIT) {
+        deathRowRef.current = {}
+        return
+      }
+
+      const candidateCount = sorted.length - SOFT_LIMIT
+      const deathCandidates = sorted.slice(0, candidateCount)
+      const survivors = sorted.slice(candidateCount)
+
+      survivors.forEach((term) => {
+        delete deathRow[term.id]
+      })
+
+      deathCandidates.forEach((term) => {
+        if (deathRow[term.id] == null) {
+          deathRow[term.id] = now
+          return
+        }
+        if (now - deathRow[term.id] >= DEATH_ROW_MS) {
+          removeTermById(term.id)
+          delete deathRow[term.id]
+        }
+      })
+    }, 1000)
+
+    return () => clearInterval(intervalId)
+  }, [])
+}

--- a/Frontend/src/presentation/hooks/useBubbleLifecycle.ts
+++ b/Frontend/src/presentation/hooks/useBubbleLifecycle.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react'
 import { useTermStore } from '../../stores/termStore'
+import { useTermMapWindowSettingsStore } from '../../stores/termMapWindowSettingsStore'
 
-export const SOFT_LIMIT = 20
-export const HARD_LIMIT = 30
+export const LEGACY_SOFT_LIMIT = 20
 export const DEATH_ROW_MS = 5000
 
 export function useBubbleLifecycle() {
@@ -10,11 +10,14 @@ export function useBubbleLifecycle() {
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      const { activeTerms, termTimestamps, removeTermById } = useTermStore.getState()
+      const { activeTerms, termTimestamps, pinnedTermIds, removeTermById } = useTermStore.getState()
+      const maxVisibleTerms = useTermMapWindowSettingsStore.getState().maxVisibleTerms
+      const hardLimit = maxVisibleTerms
+      const softLimit = Math.min(LEGACY_SOFT_LIMIT, hardLimit)
       const deathRow = deathRowRef.current
       const now = Date.now()
 
-      if (activeTerms.length <= SOFT_LIMIT) {
+      if (activeTerms.length <= softLimit) {
         deathRowRef.current = {}
         return
       }
@@ -23,23 +26,32 @@ export function useBubbleLifecycle() {
         (a, b) => (termTimestamps[a.id] ?? 0) - (termTimestamps[b.id] ?? 0),
       )
 
-      if (sorted.length > HARD_LIMIT) {
-        const overflowCount = sorted.length - HARD_LIMIT
-        const overflowTerms = sorted.splice(0, overflowCount)
-        overflowTerms.forEach((term) => {
+      if (sorted.length > hardLimit) {
+        let overflowCount = sorted.length - hardLimit
+        for (const term of sorted) {
+          if (overflowCount <= 0) break
+          if (pinnedTermIds.has(term.id)) continue
           removeTermById(term.id)
           delete deathRow[term.id]
-        })
+          overflowCount -= 1
+        }
       }
 
-      if (sorted.length <= SOFT_LIMIT) {
+      const refreshedActiveTerms = useTermStore.getState().activeTerms
+      if (refreshedActiveTerms.length <= softLimit) {
         deathRowRef.current = {}
         return
       }
 
-      const candidateCount = sorted.length - SOFT_LIMIT
-      const deathCandidates = sorted.slice(0, candidateCount)
-      const survivors = sorted.slice(candidateCount)
+      const refreshedSorted = [...refreshedActiveTerms].sort(
+        (a, b) => (termTimestamps[a.id] ?? 0) - (termTimestamps[b.id] ?? 0),
+      )
+      const candidateCount = refreshedSorted.length - softLimit
+      const deathCandidates = refreshedSorted
+        .filter((term) => !pinnedTermIds.has(term.id))
+        .slice(0, candidateCount)
+      const candidateIds = new Set(deathCandidates.map((term) => term.id))
+      const survivors = refreshedSorted.filter((term) => !candidateIds.has(term.id))
 
       survivors.forEach((term) => {
         delete deathRow[term.id]

--- a/Frontend/src/stores/__tests__/termMapWindowSettingsStore.test.ts
+++ b/Frontend/src/stores/__tests__/termMapWindowSettingsStore.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it } from 'bun:test'
 import {
   TERM_MAP_AUTO_SWITCH_INTERVAL_MAX,
   TERM_MAP_BUBBLE_SIZE_SCALE_MAX,
+  TERM_MAP_MAX_VISIBLE_TERMS_MAX,
+  TERM_MAP_MAX_VISIBLE_TERMS_MIN,
   TERM_MAP_MASTER_SIZE_SCALE_MIN,
   TERM_MAP_TEXT_FONT_SIZE_MIN,
   useTermMapWindowSettingsStore,
@@ -18,6 +20,7 @@ describe('termMapWindowSettingsStore', () => {
       textFontSizePx: 12,
       autoSwitchEnabled: false,
       autoSwitchIntervalSec: 4,
+      maxVisibleTerms: 30,
     })
   })
 
@@ -38,12 +41,15 @@ describe('termMapWindowSettingsStore', () => {
   it('自動切り替え設定を保存できる', () => {
     useTermMapWindowSettingsStore.getState().setAutoSwitchEnabled(true)
     useTermMapWindowSettingsStore.getState().setAutoSwitchIntervalSec(7)
+    useTermMapWindowSettingsStore.getState().setMaxVisibleTerms(18)
 
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
     expect(useTermMapWindowSettingsStore.getState().autoSwitchEnabled).toBe(true)
     expect(useTermMapWindowSettingsStore.getState().autoSwitchIntervalSec).toBe(7)
+    expect(useTermMapWindowSettingsStore.getState().maxVisibleTerms).toBe(18)
     expect(stored.autoSwitchEnabled).toBe(true)
     expect(stored.autoSwitchIntervalSec).toBe(7)
+    expect(stored.maxVisibleTerms).toBe(18)
   })
 
   it('範囲外の値はクランプする', () => {
@@ -51,10 +57,17 @@ describe('termMapWindowSettingsStore', () => {
     useTermMapWindowSettingsStore.getState().setBubbleSizeScale(99)
     useTermMapWindowSettingsStore.getState().setTextFontSizePx(1)
     useTermMapWindowSettingsStore.getState().setAutoSwitchIntervalSec(99)
+    useTermMapWindowSettingsStore.getState().setMaxVisibleTerms(999)
 
     expect(useTermMapWindowSettingsStore.getState().masterSizeScale).toBe(TERM_MAP_MASTER_SIZE_SCALE_MIN)
     expect(useTermMapWindowSettingsStore.getState().bubbleSizeScale).toBe(TERM_MAP_BUBBLE_SIZE_SCALE_MAX)
     expect(useTermMapWindowSettingsStore.getState().textFontSizePx).toBe(TERM_MAP_TEXT_FONT_SIZE_MIN)
     expect(useTermMapWindowSettingsStore.getState().autoSwitchIntervalSec).toBe(TERM_MAP_AUTO_SWITCH_INTERVAL_MAX)
+    expect(useTermMapWindowSettingsStore.getState().maxVisibleTerms).toBe(TERM_MAP_MAX_VISIBLE_TERMS_MAX)
+  })
+
+  it('最大表示数の下限をクランプする', () => {
+    useTermMapWindowSettingsStore.getState().setMaxVisibleTerms(1)
+    expect(useTermMapWindowSettingsStore.getState().maxVisibleTerms).toBe(TERM_MAP_MAX_VISIBLE_TERMS_MIN)
   })
 })

--- a/Frontend/src/stores/__tests__/termStore.test.ts
+++ b/Frontend/src/stores/__tests__/termStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
 import { useTermStore } from '../termStore'
 import type { Term } from '../../domain/entities/Term'
+import { useTermMapWindowSettingsStore } from '../termMapWindowSettingsStore'
 
 const term1: Term = {
   id: '1', word: 'React', kana: 'リアクト',
@@ -12,9 +13,27 @@ const term2: Term = {
   shortDesc: 'コンテナ', longDesc: '詳細',
   category: 'Infra', score: 2, relatedTerms: [],
 }
+const makeTerm = (id: string): Term => ({
+  id,
+  word: `word-${id}`,
+  kana: `かな-${id}`,
+  shortDesc: 'desc',
+  longDesc: 'long',
+  category: 'General',
+  score: 1,
+  relatedTerms: [],
+})
 
 describe('termStore', () => {
   beforeEach(() => {
+    useTermMapWindowSettingsStore.setState({
+      masterSizeScale: 1,
+      bubbleSizeScale: 1,
+      textFontSizePx: 12,
+      autoSwitchEnabled: false,
+      autoSwitchIntervalSec: 4,
+      maxVisibleTerms: 30,
+    })
     useTermStore.setState({
       activeTerms: [],
       termTimestamps: {},
@@ -36,6 +55,35 @@ describe('termStore', () => {
     const state = useTermStore.getState()
     expect(state.activeTerms).toHaveLength(1)
     expect(Object.keys(state.termTimestamps)).toHaveLength(1)
+  })
+
+  it('maxVisibleTerms 上限を超える追加は抑制される', () => {
+    useTermMapWindowSettingsStore.getState().setMaxVisibleTerms(5)
+    useTermStore.getState().addTerms([
+      makeTerm('a'),
+      makeTerm('b'),
+      makeTerm('c'),
+      makeTerm('d'),
+      makeTerm('e'),
+      makeTerm('f'),
+    ])
+    expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual(['a', 'b', 'c', 'd', 'e'])
+  })
+
+  it('表示枠がスターで埋まっている場合は新規追加しない', () => {
+    useTermMapWindowSettingsStore.getState().setMaxVisibleTerms(5)
+    useTermStore.getState().addTerms([
+      makeTerm('p1'),
+      makeTerm('p2'),
+      makeTerm('p3'),
+      makeTerm('p4'),
+      makeTerm('p5'),
+    ])
+    for (const id of ['p1', 'p2', 'p3', 'p4', 'p5']) {
+      useTermStore.getState().togglePin(id)
+    }
+    useTermStore.getState().addTerms([makeTerm('extra')])
+    expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual(['p1', 'p2', 'p3', 'p4', 'p5'])
   })
 
   it('updateTermScore で対象のスコアを更新できる', () => {

--- a/Frontend/src/stores/__tests__/termStore.test.ts
+++ b/Frontend/src/stores/__tests__/termStore.test.ts
@@ -17,6 +17,7 @@ describe('termStore', () => {
   beforeEach(() => {
     useTermStore.setState({
       activeTerms: [],
+      termTimestamps: {},
       selectedTerm: null,
       searchHistory: [],
       pinnedTermIds: new Set(),
@@ -25,12 +26,16 @@ describe('termStore', () => {
 
   it('用語を追加できる', () => {
     useTermStore.getState().addTerms([term1])
-    expect(useTermStore.getState().activeTerms).toHaveLength(1)
+    const state = useTermStore.getState()
+    expect(state.activeTerms).toHaveLength(1)
+    expect(typeof state.termTimestamps['1']).toBe('number')
   })
 
   it('重複IDの用語は追加されない', () => {
     useTermStore.getState().addTerms([term1, term1])
-    expect(useTermStore.getState().activeTerms).toHaveLength(1)
+    const state = useTermStore.getState()
+    expect(state.activeTerms).toHaveLength(1)
+    expect(Object.keys(state.termTimestamps)).toHaveLength(1)
   })
 
   it('updateTermScore で対象のスコアを更新できる', () => {
@@ -81,6 +86,24 @@ describe('termStore', () => {
     expect(s.selectedTerm).toBeNull()
     expect(s.searchHistory).toHaveLength(0)
     expect(s.pinnedTermIds.size).toBe(0)
+    expect(Object.keys(s.termTimestamps)).toHaveLength(0)
+  })
+
+  it('removeTermById でタイムスタンプも削除される', () => {
+    useTermStore.getState().addTerms([term1, term2])
+    useTermStore.getState().removeTermById('1')
+    const s = useTermStore.getState()
+    expect(s.activeTerms.map((term) => term.id)).toEqual(['2'])
+    expect(s.termTimestamps['1']).toBeUndefined()
+    expect(typeof s.termTimestamps['2']).toBe('number')
+  })
+
+  it('clearActiveTerms で用語とタイムスタンプをまとめてクリアする', () => {
+    useTermStore.getState().addTerms([term1, term2])
+    useTermStore.getState().clearActiveTerms()
+    const s = useTermStore.getState()
+    expect(s.activeTerms).toHaveLength(0)
+    expect(Object.keys(s.termTimestamps)).toHaveLength(0)
   })
 
   it('addTerms は category を常に空文字に正規化する', () => {
@@ -105,7 +128,9 @@ describe('termStore', () => {
     }
     useTermStore.getState().addTerms([term1, demoTerm])
     useTermStore.getState().stripDemoImportantTerms()
-    expect(useTermStore.getState().activeTerms).toHaveLength(1)
-    expect(useTermStore.getState().activeTerms[0]?.id).toBe('1')
+    const s = useTermStore.getState()
+    expect(s.activeTerms).toHaveLength(1)
+    expect(s.activeTerms[0]?.id).toBe('1')
+    expect(s.termTimestamps['demo-important-react']).toBeUndefined()
   })
 })

--- a/Frontend/src/stores/termMapWindowSettingsStore.ts
+++ b/Frontend/src/stores/termMapWindowSettingsStore.ts
@@ -10,6 +10,8 @@ export const TERM_MAP_TEXT_FONT_SIZE_MIN = 8
 export const TERM_MAP_TEXT_FONT_SIZE_MAX = 20
 export const TERM_MAP_AUTO_SWITCH_INTERVAL_MIN = 1
 export const TERM_MAP_AUTO_SWITCH_INTERVAL_MAX = 10
+export const TERM_MAP_MAX_VISIBLE_TERMS_MIN = 5
+export const TERM_MAP_MAX_VISIBLE_TERMS_MAX = 30
 
 export interface TermMapWindowSettings {
   masterSizeScale: number
@@ -17,6 +19,7 @@ export interface TermMapWindowSettings {
   textFontSizePx: number
   autoSwitchEnabled: boolean
   autoSwitchIntervalSec: number
+  maxVisibleTerms: number
 }
 
 interface TermMapWindowSettingsState extends TermMapWindowSettings {
@@ -25,6 +28,7 @@ interface TermMapWindowSettingsState extends TermMapWindowSettings {
   setTextFontSizePx: (value: number) => void
   setAutoSwitchEnabled: (value: boolean) => void
   setAutoSwitchIntervalSec: (value: number) => void
+  setMaxVisibleTerms: (value: number) => void
 }
 
 const DEFAULT_SETTINGS: TermMapWindowSettings = {
@@ -33,6 +37,7 @@ const DEFAULT_SETTINGS: TermMapWindowSettings = {
   textFontSizePx: 12,
   autoSwitchEnabled: false,
   autoSwitchIntervalSec: 4,
+  maxVisibleTerms: 30,
 }
 
 const clamp = (min: number, max: number, value: number): number =>
@@ -61,6 +66,11 @@ const normalizeSettings = (settings: Partial<TermMapWindowSettings>): TermMapWin
     TERM_MAP_AUTO_SWITCH_INTERVAL_MIN,
     TERM_MAP_AUTO_SWITCH_INTERVAL_MAX,
     settings.autoSwitchIntervalSec ?? DEFAULT_SETTINGS.autoSwitchIntervalSec,
+  )),
+  maxVisibleTerms: Math.round(clamp(
+    TERM_MAP_MAX_VISIBLE_TERMS_MIN,
+    TERM_MAP_MAX_VISIBLE_TERMS_MAX,
+    settings.maxVisibleTerms ?? DEFAULT_SETTINGS.maxVisibleTerms,
   )),
 })
 
@@ -110,6 +120,12 @@ export const useTermMapWindowSettingsStore = create<TermMapWindowSettingsState>(
 
   setAutoSwitchIntervalSec: (value) => {
     const next = normalizeSettings({ ...get(), autoSwitchIntervalSec: value })
+    saveSettings(next)
+    set(next)
+  },
+
+  setMaxVisibleTerms: (value) => {
+    const next = normalizeSettings({ ...get(), maxVisibleTerms: value })
     saveSettings(next)
     set(next)
   },

--- a/Frontend/src/stores/termStore.ts
+++ b/Frontend/src/stores/termStore.ts
@@ -5,6 +5,7 @@ import { DEMO_IMPORTANT_TERM_ID_PREFIX } from '../debug/demo/mockImportantTerms'
 
 interface TermState {
   activeTerms: Term[]
+  termTimestamps: Record<string, number>
   selectedTerm: Term | null
   searchHistory: Term[]
   pinnedTermIds: Set<string>
@@ -19,29 +20,36 @@ interface TermState {
   addToHistory: (term: Term) => void
   clearHistory: () => void
   clearActiveTerms: () => void
-  /** 用語・選択・履歴・ピン・クリック重みをまとめて初期化（グローバルリセット用） */
+  /** 用語・選択・履歴・ピンをまとめて初期化（グローバルリセット用） */
   resetSession: () => void
 }
 
 export const useTermStore = create<TermState>((set) => ({
   activeTerms: [],
+  termTimestamps: {},
   selectedTerm: null,
   searchHistory: [],
   pinnedTermIds: new Set(),
 
   addTerms: (terms) => set((state) => {
+    const now = Date.now()
     const existingIds = new Set(state.activeTerms.map(t => t.id))
     const newTerms: Term[] = []
+    const nextTermTimestamps = { ...state.termTimestamps }
     for (const t of terms) {
       if (!existingIds.has(t.id)) {
         existingIds.add(t.id)
+        nextTermTimestamps[t.id] = now
         newTerms.push({
           ...t,
           category: normalizeTermCategory(t.category),
         })
       }
     }
-    return { activeTerms: [...state.activeTerms, ...newTerms] }
+    return {
+      activeTerms: [...state.activeTerms, ...newTerms],
+      termTimestamps: nextTermTimestamps,
+    }
   }),
 
   updateTermScore: (id, score) => set((state) => ({
@@ -50,15 +58,25 @@ export const useTermStore = create<TermState>((set) => ({
     )),
   })),
 
-  removeTermById: (id) => set((state) => ({
-    activeTerms: state.activeTerms.filter(t => t.id !== id),
-  })),
+  removeTermById: (id) => set((state) => {
+    const nextTermTimestamps = { ...state.termTimestamps }
+    delete nextTermTimestamps[id]
+    return {
+      activeTerms: state.activeTerms.filter(t => t.id !== id),
+      termTimestamps: nextTermTimestamps,
+    }
+  }),
 
-  stripDemoImportantTerms: () => set((state) => ({
-    activeTerms: state.activeTerms.filter(
+  stripDemoImportantTerms: () => set((state) => {
+    const activeTerms = state.activeTerms.filter(
       t => !t.id.startsWith(DEMO_IMPORTANT_TERM_ID_PREFIX),
-    ),
-  })),
+    )
+    const activeIds = new Set(activeTerms.map((term) => term.id))
+    const nextTermTimestamps = Object.fromEntries(
+      Object.entries(state.termTimestamps).filter(([id]) => activeIds.has(id)),
+    )
+    return { activeTerms, termTimestamps: nextTermTimestamps }
+  }),
 
   selectTerm: (term) => set({ selectedTerm: term }),
 
@@ -76,10 +94,11 @@ export const useTermStore = create<TermState>((set) => ({
 
   clearHistory: () => set({ searchHistory: [] }),
 
-  clearActiveTerms: () => set({ activeTerms: [] }),
+  clearActiveTerms: () => set({ activeTerms: [], termTimestamps: {} }),
 
   resetSession: () => set({
     activeTerms: [],
+    termTimestamps: {},
     selectedTerm: null,
     searchHistory: [],
     pinnedTermIds: new Set(),

--- a/Frontend/src/stores/termStore.ts
+++ b/Frontend/src/stores/termStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import type { Term } from '../domain/entities/Term'
 import { normalizeTermCategory } from '../domain/entities/Term'
 import { DEMO_IMPORTANT_TERM_ID_PREFIX } from '../debug/demo/mockImportantTerms'
+import { useTermMapWindowSettingsStore } from './termMapWindowSettingsStore'
 
 interface TermState {
   activeTerms: Term[]
@@ -33,10 +34,21 @@ export const useTermStore = create<TermState>((set) => ({
 
   addTerms: (terms) => set((state) => {
     const now = Date.now()
+    const maxVisibleTerms = useTermMapWindowSettingsStore.getState().maxVisibleTerms
+    const pinnedCount = state.activeTerms.filter((term) => state.pinnedTermIds.has(term.id)).length
+    if (state.activeTerms.length >= maxVisibleTerms && pinnedCount >= maxVisibleTerms) {
+      return state
+    }
+    const availableSlots = Math.max(0, maxVisibleTerms - state.activeTerms.length)
+    if (availableSlots <= 0) {
+      return state
+    }
+
     const existingIds = new Set(state.activeTerms.map(t => t.id))
     const newTerms: Term[] = []
     const nextTermTimestamps = { ...state.termTimestamps }
     for (const t of terms) {
+      if (newTerms.length >= availableSlots) break
       if (!existingIds.has(t.id)) {
         existingIds.add(t.id)
         nextTermTimestamps[t.id] = now


### PR DESCRIPTION
## Summary
- `useBubbleLifecycle` を導入し、`termTimestamps` を使ったバブル寿命管理（soft/hard上限判定と5秒death-row削除）を実装
- バブルウィンドウ内に `maxVisibleTerms` スライダー（5〜30）を追加し、表示枠上限を設定可能に変更
- 表示枠がスター語で埋まった場合は新規バブルを追加しない制御を `termStore.addTerms` に追加し、Step6ドキュメントを更新

## Test plan
- [x] `cd Frontend && bun test src/stores/__tests__/termMapWindowSettingsStore.test.ts src/stores/__tests__/termStore.test.ts src/infrastructure/adapters src/presentation/utils/__tests__/importanceRanking.test.ts src/presentation/hooks/__tests__/transcriptionModeSync.test.ts`
- [x] `cd Frontend && bun run build`

Made with [Cursor](https://cursor.com)