### PR TITLE
fix: 用語マップ設定をヘッダーへ統一

### DIFF
--- a/Frontend/src/app/components/BubbleCloud.tsx
+++ b/Frontend/src/app/components/BubbleCloud.tsx
@@ -2,16 +2,12 @@ import React, { useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Term } from '../data/terms';
 import { TermBubble } from './TermBubble';
-import { Hexagon, Shuffle, Pause, ChevronUp, ChevronDown } from 'lucide-react';
+import { Hexagon } from 'lucide-react';
 import { useContentFontScaleStore } from '../../stores/contentFontScaleStore';
 import { scaledContentFontPx } from '../utils/contentFontScale';
 import { useAccentTheme } from '../../theme/AccentThemeContext';
-import { accentRgba, accentSliderStyle, micStartButtonStyle, termChipStyle } from '../../theme/accentStyles';
+import { termChipStyle } from '../../theme/accentStyles';
 import {
-  TERM_MAP_AUTO_SWITCH_INTERVAL_MAX,
-  TERM_MAP_AUTO_SWITCH_INTERVAL_MIN,
-  TERM_MAP_MAX_VISIBLE_TERMS_MAX,
-  TERM_MAP_MAX_VISIBLE_TERMS_MIN,
   useTermMapWindowSettingsStore,
 } from '../../stores/termMapWindowSettingsStore';
 
@@ -65,12 +61,9 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
   const intervalSec = useTermMapWindowSettingsStore(s => s.autoSwitchIntervalSec);
   const maxVisibleTerms = useTermMapWindowSettingsStore(s => s.maxVisibleTerms);
   const setAutoSwitchEnabled = useTermMapWindowSettingsStore(s => s.setAutoSwitchEnabled);
-  const setAutoSwitchIntervalSec = useTermMapWindowSettingsStore(s => s.setAutoSwitchIntervalSec);
-  const setMaxVisibleTerms = useTermMapWindowSettingsStore(s => s.setMaxVisibleTerms);
   const categories = ['ALL', 'ピン中', ...Object.keys(CATEGORY_COLORS)];
   const effectiveBubbleScale = masterSizeScale * bubbleSizeScale;
 
-  const [showSlider, setShowSlider] = useState(false);
   const activeTermsRef = useRef(activeTerms);
 
   // 用語⇔説明の反転状態を管理するIDセット（Auto-Play ONのときのみ使用）
@@ -247,11 +240,6 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
     if (activeTerms.length === 0 && isAutoPlay) setAutoSwitchEnabled(false);
   }, [activeTerms.length, isAutoPlay, setAutoSwitchEnabled]);
 
-  const toggleAutoPlay = () => {
-    if (activeTerms.length === 0) return;
-    setAutoSwitchEnabled(!isAutoPlay);
-  };
-
   return (
     <div className={`flex flex-col h-full transition-colors ${dk ? 'bg-[#0d0e1a]' : 'bg-white'}`}>
       {/* Header: filter + scale slider + term count — 1 row */}
@@ -401,184 +389,6 @@ export const BubbleCloud: React.FC<BubbleCloudProps> = ({
           </AnimatePresence>
         )}
 
-        {/* Auto-play button (bottom-right, always visible) */}
-        <div className="absolute bottom-4 right-4 flex flex-col items-end gap-3 z-10">
-
-          {/* Slider panel (appears above button) */}
-          <AnimatePresence>
-            {showSlider && (
-              <motion.div
-                initial={{ opacity: 0, y: 10, scale: 0.95 }}
-                animate={{ opacity: 1, y: 0, scale: 1 }}
-                exit={{ opacity: 0, y: 10, scale: 0.95 }}
-                transition={{ duration: 0.18 }}
-                className={`flex flex-col gap-3 p-4 rounded-2xl border shadow-2xl ${
-                  dk ? 'bg-[#12132a] border-slate-700/60 text-slate-200' : 'bg-white border-slate-200 text-slate-700'
-                }`}
-                style={{ minWidth: 180 }}
-              >
-                <div className="flex items-center justify-between">
-                  <span className="text-xs font-black">切換え間隔</span>
-                  <span
-                    className={`text-lg font-black tabular-nums ${isAutoPlay ? '' : dk ? 'text-slate-400' : 'text-slate-500'}`}
-                    style={isAutoPlay ? { color: accentRgba(rgb, dk ? 0.95 : 0.85) } : undefined}
-                  >
-                    {intervalSec}<span className="text-xs font-bold ml-0.5">秒</span>
-                  </span>
-                </div>
-
-                {/* Large slider */}
-                <div className="relative flex items-center">
-                  <input
-                    type="range"
-                    min={TERM_MAP_AUTO_SWITCH_INTERVAL_MIN}
-                    max={TERM_MAP_AUTO_SWITCH_INTERVAL_MAX}
-                    step={1}
-                    value={intervalSec}
-                    onChange={e => setAutoSwitchIntervalSec(Number(e.target.value))}
-                    disabled={activeTerms.length === 0}
-                    className={`w-full h-2.5 rounded-full appearance-none cursor-pointer ${
-                      activeTerms.length === 0 ? 'cursor-not-allowed opacity-40' : ''
-                    }`}
-                    style={{
-                      background: dk ? '#1e293b' : '#e2e8f0',
-                      ...(activeTerms.length === 0 ? {} : accentSliderStyle(rgb)),
-                    }}
-                  />
-                </div>
-
-                {/* Tick labels */}
-                <div className={`flex justify-between text-[9px] font-bold -mt-1 ${dk ? 'text-slate-600' : 'text-slate-400'}`}>
-                  <span>遅(1s)</span>
-                  <span>速(10s)</span>
-                </div>
-
-                {/* Step buttons */}
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={() => setAutoSwitchIntervalSec(intervalSec - 1)}
-                    disabled={intervalSec <= TERM_MAP_AUTO_SWITCH_INTERVAL_MIN}
-                    className={`flex-1 py-1.5 rounded-lg text-xs font-bold border transition-colors ${
-                      dk ? 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700 disabled:opacity-30' : 'border-slate-200 bg-slate-50 text-slate-600 hover:bg-slate-100 disabled:opacity-30'
-                    }`}
-                  >
-                    <ChevronDown size={14} className="mx-auto" />
-                  </button>
-                  <span
-                    className={`text-xs font-mono font-black w-10 text-center ${isAutoPlay ? '' : dk ? 'text-slate-400' : 'text-slate-500'}`}
-                    style={isAutoPlay ? { color: accentRgba(rgb, dk ? 0.95 : 0.85) } : undefined}
-                  >
-                    {intervalSec}s
-                  </span>
-                  <button
-                    onClick={() => setAutoSwitchIntervalSec(intervalSec + 1)}
-                    disabled={intervalSec >= TERM_MAP_AUTO_SWITCH_INTERVAL_MAX}
-                    className={`flex-1 py-1.5 rounded-lg text-xs font-bold border transition-colors ${
-                      dk ? 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700 disabled:opacity-30' : 'border-slate-200 bg-slate-50 text-slate-600 hover:bg-slate-100 disabled:opacity-30'
-                    }`}
-                  >
-                    <ChevronUp size={14} className="mx-auto" />
-                  </button>
-                </div>
-
-                <div className={`h-px ${dk ? 'bg-slate-700/70' : 'bg-slate-200'}`} />
-
-                <div className="flex items-center justify-between">
-                  <span className="text-xs font-black">最大表示数</span>
-                  <span className={`text-lg font-black tabular-nums ${dk ? 'text-slate-300' : 'text-slate-600'}`}>
-                    {maxVisibleTerms}<span className="text-xs font-bold ml-0.5">語</span>
-                  </span>
-                </div>
-                <div className="relative flex items-center">
-                  <input
-                    type="range"
-                    min={TERM_MAP_MAX_VISIBLE_TERMS_MIN}
-                    max={TERM_MAP_MAX_VISIBLE_TERMS_MAX}
-                    step={1}
-                    value={maxVisibleTerms}
-                    onChange={e => setMaxVisibleTerms(Number(e.target.value))}
-                    className="w-full h-2.5 rounded-full appearance-none cursor-pointer"
-                    style={{
-                      background: dk ? '#1e293b' : '#e2e8f0',
-                      ...accentSliderStyle(rgb),
-                    }}
-                  />
-                </div>
-                <div className={`flex justify-between text-[9px] font-bold -mt-1 ${dk ? 'text-slate-600' : 'text-slate-400'}`}>
-                  <span>少({TERM_MAP_MAX_VISIBLE_TERMS_MIN})</span>
-                  <span>多({TERM_MAP_MAX_VISIBLE_TERMS_MAX})</span>
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
-
-          {/* Auto-play main button */}
-          <div className="flex flex-col items-center gap-1.5">
-            <div className="flex items-end gap-2">
-              {/* Speed toggle (小) */}
-              <motion.button
-                onClick={() => setShowSlider(s => !s)}
-                whileTap={{ scale: 0.92 }}
-                whileHover={{ scale: 1.06 }}
-                title="間隔の設定"
-                className={`w-10 h-10 rounded-full flex items-center justify-center border-2 shadow-lg text-xs font-black transition-colors ${
-                  showSlider ? '' : (dk ? 'bg-slate-800 border-slate-600 text-slate-400 hover:border-slate-500' : 'bg-white border-slate-300 text-slate-500 hover:border-slate-400')
-                }`}
-                style={
-                  showSlider
-                    ? {
-                        backgroundColor: accentRgba(rgb, dk ? 0.28 : 0.12),
-                        borderColor: accentRgba(rgb, dk ? 0.55 : 0.45),
-                        color: accentRgba(rgb, dk ? 0.95 : 0.9),
-                      }
-                    : undefined
-                }
-              >
-                {intervalSec}s
-              </motion.button>
-
-              {/* Main auto-play button (大) */}
-              <motion.button
-                onClick={toggleAutoPlay}
-                disabled={activeTerms.length === 0}
-                whileTap={{ scale: 0.92 }}
-                whileHover={{ scale: activeTerms.length === 0 ? 1 : 1.06 }}
-                className={`w-16 h-16 rounded-full flex items-center justify-center shadow-2xl relative transition-[filter] ${
-                  activeTerms.length === 0
-                    ? (dk ? 'bg-slate-800 border-2 border-slate-700 text-slate-700 cursor-not-allowed' : 'bg-slate-100 border-2 border-slate-200 text-slate-300 cursor-not-allowed')
-                    : isAutoPlay
-                      ? 'border-2 border-transparent text-white hover:brightness-110'
-                      : (dk ? 'bg-slate-800 border-2 border-slate-600 text-slate-300 cursor-pointer hover:brightness-110' : 'bg-white border-2 border-slate-300 text-slate-500 cursor-pointer hover:brightness-110')
-                }`}
-                style={
-                  activeTerms.length === 0
-                    ? undefined
-                    : isAutoPlay
-                      ? micStartButtonStyle(rgb, dk)
-                      : {
-                          borderColor: accentRgba(rgb, dk ? 0.48 : 0.35),
-                          color: accentRgba(rgb, dk ? 0.92 : 0.82),
-                        }
-                }
-                title={isAutoPlay ? '自動切換えを停止' : '自動切換えを開始'}
-              >
-                {isAutoPlay && (
-                  <span
-                    className="absolute inset-0 rounded-full animate-ping opacity-20 pointer-events-none"
-                    style={{ backgroundColor: accentRgba(rgb, 0.45) }}
-                  />
-                )}
-                {isAutoPlay ? <Pause size={22} fill="currentColor" /> : <Shuffle size={22} />}
-              </motion.button>
-            </div>
-            <span
-              className={`text-[10px] font-bold ${isAutoPlay ? '' : dk ? 'text-slate-600' : 'text-slate-400'}`}
-              style={isAutoPlay ? { color: accentRgba(rgb, dk ? 0.95 : 0.88) } : undefined}
-            >
-              {isAutoPlay ? '切換え中' : '自動切換え'}
-            </span>
-          </div>
-        </div>
       </div>
         </>
       )}

--- a/Frontend/src/presentation/layout/LayoutEngine.tsx
+++ b/Frontend/src/presentation/layout/LayoutEngine.tsx
@@ -28,6 +28,8 @@ import {
   TERM_MAP_AUTO_SWITCH_INTERVAL_MIN,
   TERM_MAP_BUBBLE_SIZE_SCALE_MAX,
   TERM_MAP_BUBBLE_SIZE_SCALE_MIN,
+  TERM_MAP_MAX_VISIBLE_TERMS_MAX,
+  TERM_MAP_MAX_VISIBLE_TERMS_MIN,
   TERM_MAP_MASTER_SIZE_SCALE_MAX,
   TERM_MAP_MASTER_SIZE_SCALE_MIN,
   TERM_MAP_TEXT_FONT_SIZE_MAX,
@@ -208,11 +210,13 @@ const WindowSettingsPanel: React.FC<WindowSettingsPanelProps> = ({
   const termMapTextFontSizePx = useTermMapWindowSettingsStore(s => s.textFontSizePx)
   const termMapAutoSwitchEnabled = useTermMapWindowSettingsStore(s => s.autoSwitchEnabled)
   const termMapAutoSwitchIntervalSec = useTermMapWindowSettingsStore(s => s.autoSwitchIntervalSec)
+  const termMapMaxVisibleTerms = useTermMapWindowSettingsStore(s => s.maxVisibleTerms)
   const setTermMapMasterSizeScale = useTermMapWindowSettingsStore(s => s.setMasterSizeScale)
   const setTermMapBubbleSizeScale = useTermMapWindowSettingsStore(s => s.setBubbleSizeScale)
   const setTermMapTextFontSizePx = useTermMapWindowSettingsStore(s => s.setTextFontSizePx)
   const setTermMapAutoSwitchEnabled = useTermMapWindowSettingsStore(s => s.setAutoSwitchEnabled)
   const setTermMapAutoSwitchIntervalSec = useTermMapWindowSettingsStore(s => s.setAutoSwitchIntervalSec)
+  const setTermMapMaxVisibleTerms = useTermMapWindowSettingsStore(s => s.setMaxVisibleTerms)
   const importanceRankingMasterSizeScale = useImportanceRankingWindowSettingsStore(s => s.masterSizeScale)
   const importanceRankingFontSizePx = useImportanceRankingWindowSettingsStore(s => s.fontSizePx)
   const importanceRankingVisibleCount = useImportanceRankingWindowSettingsStore(s => s.visibleCount)
@@ -400,6 +404,17 @@ const WindowSettingsPanel: React.FC<WindowSettingsPanelProps> = ({
                 darkMode={dk}
                 accentRgb={accentRgb}
                 onChange={setTermMapTextFontSizePx}
+              />
+              <SettingsSlider
+                label="最大表示数"
+                valueLabel={`${termMapMaxVisibleTerms}語`}
+                value={termMapMaxVisibleTerms}
+                min={TERM_MAP_MAX_VISIBLE_TERMS_MIN}
+                max={TERM_MAP_MAX_VISIBLE_TERMS_MAX}
+                step={1}
+                darkMode={dk}
+                accentRgb={accentRgb}
+                onChange={setTermMapMaxVisibleTerms}
               />
             </div>
           </section>


### PR DESCRIPTION
## Summary
- 用語マップのヘッダー設定（歯車）パネルに `最大表示数`（5〜30）スライダーを追加
- 用語マップ右下の自動切り替え表示UI（丸ボタン＋ポップアップ）を非表示化
- 設定導線をヘッダー設定パネルに一本化し、誤認しやすいUIを解消

## Test plan
- [x] `cd Frontend && bun test src/stores/__tests__/termMapWindowSettingsStore.test.ts src/stores/__tests__/termStore.test.ts src/infrastructure/adapters src/presentation/utils/__tests__/importanceRanking.test.ts src/presentation/hooks/__tests__/transcriptionModeSync.test.ts`
- [x] `cd Frontend && bun run build`

Made with [Cursor](https://cursor.com)