### PR TITLE
fix: SSE可視化とバブル上限制御の不整合を修正

### DIFF
--- a/Frontend/src/infrastructure/adapters/ScoreThresholdFilter.ts
+++ b/Frontend/src/infrastructure/adapters/ScoreThresholdFilter.ts
@@ -2,9 +2,27 @@ import type { Term } from '../../domain/entities/Term'
 
 export const DEFAULT_SCORE_THRESHOLD = 0.1
 
+export interface ScoreThresholdPartition {
+  passed: Term[]
+  rejected: Term[]
+}
+
 export function filterByScore(
   terms: Term[],
   threshold: number = DEFAULT_SCORE_THRESHOLD,
 ): Term[] {
   return terms.filter((term) => term.score >= threshold)
+}
+
+export function partitionByScore(
+  terms: Term[],
+  threshold: number = DEFAULT_SCORE_THRESHOLD,
+): ScoreThresholdPartition {
+  const passed: Term[] = []
+  const rejected: Term[] = []
+  for (const term of terms) {
+    if (term.score >= threshold) passed.push(term)
+    else rejected.push(term)
+  }
+  return { passed, rejected }
 }

--- a/Frontend/src/infrastructure/adapters/__tests__/ScoreThresholdFilter.test.ts
+++ b/Frontend/src/infrastructure/adapters/__tests__/ScoreThresholdFilter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import type { Term } from '../../../domain/entities/Term'
-import { filterByScore } from '../ScoreThresholdFilter'
+import { filterByScore, partitionByScore } from '../ScoreThresholdFilter'
 
 const makeTerm = (id: string, score: number): Term => ({
   id,
@@ -30,5 +30,15 @@ describe('ScoreThresholdFilter', () => {
       makeTerm('c', 0.8),
     ], 0.7)
     expect(result.map((term) => term.id)).toEqual(['c'])
+  })
+
+  it('閾値比較を通過/除外で分割できる', () => {
+    const { passed, rejected } = partitionByScore([
+      makeTerm('a', 0.5),
+      makeTerm('b', 0.49),
+      makeTerm('c', 0.7),
+    ], 0.5)
+    expect(passed.map((term) => term.id)).toEqual(['a', 'c'])
+    expect(rejected.map((term) => term.id)).toEqual(['b'])
   })
 })

--- a/Frontend/src/infrastructure/sse/referDictScoreStream.ts
+++ b/Frontend/src/infrastructure/sse/referDictScoreStream.ts
@@ -39,6 +39,7 @@ export function buildReferDictScoreStreamUrl(text: string, baseUrl?: string): st
 
 export interface StreamReferDictScoreOptions {
   baseUrl?: string
+  onOpen?: () => void
   /** パース済みの 1 chunk（`data` 1 行分） */
   onChunk: (rows: TermRow[]) => void
   onError?: (err: unknown) => void
@@ -62,6 +63,7 @@ export function streamReferDictScores(
   return new Promise((resolve, reject) => {
     const es = new EventSource(url)
     let settled = false
+    let opened = false
 
     // 正常終了・エラー・abort のいずれかで一度だけ後始末する
     const finish = (err?: unknown) => {
@@ -74,6 +76,12 @@ export function streamReferDictScores(
       } else {
         resolve()
       }
+    }
+
+    es.onopen = () => {
+      if (opened) return
+      opened = true
+      options.onOpen?.()
     }
 
     // DB ヒット分 → LLM 追加分の順で複数回届く

--- a/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
+++ b/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
@@ -46,16 +46,16 @@ export const ReferDictScoreSseBridge: React.FC<ReferDictScoreSseBridgeProps> = (
   }, [])
 
   useReferDictScoreSse({
-    onBeforeSend: (text) => {
+    onRequestOpened: (text) => {
       usePipelineDebugStore.getState().pushSentInput(text)
     },
     onChunk: (rows) => {
       usePipelineDebugStore.getState().pushSseRows(rows)
     },
     onTerms: (terms) => {
-      const filtered = filterByScore(terms, threshold)
-      usePipelineDebugStore.getState().setFilteredTerms(threshold, filtered)
-      const adapted = adapterRef.current?.adapt(filtered)
+      const passed = filterByScore(terms, threshold)
+      usePipelineDebugStore.getState().setFilteredTerms(threshold, passed)
+      const adapted = adapterRef.current?.adapt(passed)
       if (!adapted) return
       const store = useTermStore.getState()
       store.addTerms(adapted.toAdd)

--- a/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
+++ b/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
@@ -4,7 +4,7 @@ import { useReferDictScoreSse } from '../hooks/useReferDictScoreSse'
 import { useTermStore } from '../../stores/termStore'
 import {
   DEFAULT_SCORE_THRESHOLD,
-  filterByScore,
+  partitionByScore,
 } from '../../infrastructure/adapters/ScoreThresholdFilter'
 import { defaultScoreUpdateStrategy } from '../../infrastructure/adapters/DefaultScoreUpdateStrategy'
 import { FrequencyScoreAdapter } from '../../infrastructure/adapters/FrequencyScoreAdapter'
@@ -53,9 +53,7 @@ export const ReferDictScoreSseBridge: React.FC<ReferDictScoreSseBridgeProps> = (
       usePipelineDebugStore.getState().pushSseRows(rows)
     },
     onTerms: (terms) => {
-      const passed = filterByScore(terms, threshold)
-      const passedIds = new Set(passed.map((term) => term.id))
-      const rejected = terms.filter((term) => !passedIds.has(term.id))
+      const { passed, rejected } = partitionByScore(terms, threshold)
       usePipelineDebugStore.getState().setFilteredTerms(threshold, passed, rejected)
       const adapted = adapterRef.current?.adapt(passed)
       if (!adapted) return

--- a/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
+++ b/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
@@ -54,7 +54,9 @@ export const ReferDictScoreSseBridge: React.FC<ReferDictScoreSseBridgeProps> = (
     },
     onTerms: (terms) => {
       const passed = filterByScore(terms, threshold)
-      usePipelineDebugStore.getState().setFilteredTerms(threshold, passed)
+      const passedIds = new Set(passed.map((term) => term.id))
+      const rejected = terms.filter((term) => !passedIds.has(term.id))
+      usePipelineDebugStore.getState().setFilteredTerms(threshold, passed, rejected)
       const adapted = adapterRef.current?.adapt(passed)
       if (!adapted) return
       const store = useTermStore.getState()

--- a/Frontend/src/presentation/hooks/useReferDictScoreSse.ts
+++ b/Frontend/src/presentation/hooks/useReferDictScoreSse.ts
@@ -22,6 +22,7 @@ export interface UseReferDictScoreSseOptions {
   baseUrl?: string
   trailingDebounceMs?: number
   onBeforeSend?: (text: string) => void
+  onRequestOpened?: (text: string) => void
   onChunk?: (rows: TermRow[]) => void
   onTerms?: (terms: Term[]) => void
   onError?: (err: unknown) => void
@@ -37,6 +38,7 @@ export function useReferDictScoreSse(options: UseReferDictScoreSseOptions = {}):
     baseUrl: baseUrlOption,
     trailingDebounceMs = DEFAULT_TRAILING_DEBOUNCE_MS,
     onBeforeSend,
+    onRequestOpened,
     onChunk,
     onTerms,
     onError,
@@ -56,10 +58,12 @@ export function useReferDictScoreSse(options: UseReferDictScoreSseOptions = {}):
   const onTermsRef = useRef(onTerms)
   const onErrorRef = useRef(onError)
   const onBeforeSendRef = useRef(onBeforeSend)
+  const onRequestOpenedRef = useRef(onRequestOpened)
   onChunkRef.current = onChunk
   onTermsRef.current = onTerms
   onErrorRef.current = onError
   onBeforeSendRef.current = onBeforeSend
+  onRequestOpenedRef.current = onRequestOpened
 
   /** 1 chunk ごと: API 行配列 →（任意）`mapToTerms` → 呼び出し側 */
   const deliverChunk = useCallback((rows: TermRow[]) => {
@@ -103,6 +107,7 @@ export function useReferDictScoreSse(options: UseReferDictScoreSseOptions = {}):
             // 1 文 = 1 本の EventSource。chunk は `deliverChunk` 経由で上に上がる
             await streamReferDictScores(text, {
               baseUrl,
+              onOpen: () => onRequestOpenedRef.current?.(text),
               onChunk: deliverChunk,
               onError: onErrorRef.current,
             })

--- a/Frontend/src/presentation/windows/PipelineDebugWindow/index.tsx
+++ b/Frontend/src/presentation/windows/PipelineDebugWindow/index.tsx
@@ -16,7 +16,8 @@ export const PipelineDebugWindow: React.FC<WindowProps> = ({ darkMode = true }) 
   const sentInputs = usePipelineDebugStore((s) => s.sentInputs)
   const sseTerms = usePipelineDebugStore((s) => s.sseTerms)
   const filteredThreshold = usePipelineDebugStore((s) => s.filteredThreshold)
-  const filteredTerms = usePipelineDebugStore((s) => s.filteredTerms)
+  const filteredPassedTerms = usePipelineDebugStore((s) => s.filteredPassedTerms)
+  const filteredRejectedTerms = usePipelineDebugStore((s) => s.filteredRejectedTerms)
   const bubbleTerms = usePipelineDebugStore((s) => s.bubbleTerms)
   const visibleLayers = usePipelineDebugStore((s) => s.visibleLayers)
   const toggleLayer = usePipelineDebugStore((s) => s.toggleLayer)
@@ -56,14 +57,30 @@ export const PipelineDebugWindow: React.FC<WindowProps> = ({ darkMode = true }) 
       key: 'filtered',
       body: (
         <div className="space-y-1">
-          <div className="text-[11px] opacity-80">閾値: {filteredThreshold.toFixed(2)}</div>
-          <div className="flex flex-wrap gap-2">
-            {filteredTerms.length === 0 ? <span className="text-[11px] opacity-60">通過語なし</span> : null}
-            {filteredTerms.map((term) => (
-              <span key={term.id} className="rounded border px-2 py-1 text-[11px]">
-                {term.word} ({term.score.toFixed(2)})
-              </span>
-            ))}
+          <div className="text-[11px] opacity-80">閾値: {filteredThreshold.toFixed(4)}</div>
+          <div className="space-y-2">
+            <div>
+              <div className="mb-1 text-[11px] font-bold text-emerald-400">通過</div>
+              <div className="flex flex-wrap gap-2">
+                {filteredPassedTerms.length === 0 ? <span className="text-[11px] opacity-60">通過語なし</span> : null}
+                {filteredPassedTerms.map((term) => (
+                  <span key={`passed-${term.id}`} className="rounded border px-2 py-1 text-[11px]">
+                    {term.word} ({term.score.toFixed(4)})
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div>
+              <div className="mb-1 text-[11px] font-bold text-rose-400">除外</div>
+              <div className="flex flex-wrap gap-2">
+                {filteredRejectedTerms.length === 0 ? <span className="text-[11px] opacity-60">除外語なし</span> : null}
+                {filteredRejectedTerms.map((term) => (
+                  <span key={`rejected-${term.id}`} className="rounded border px-2 py-1 text-[11px]">
+                    {term.word} ({term.score.toFixed(4)})
+                  </span>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       ),

--- a/Frontend/src/stores/__tests__/pipelineDebugStore.test.ts
+++ b/Frontend/src/stores/__tests__/pipelineDebugStore.test.ts
@@ -42,11 +42,12 @@ describe('pipelineDebugStore', () => {
 
   it('フィルタ結果とバブル表示語を更新できる', () => {
     usePipelineDebugStore.getState().setFilteredThreshold(0.35)
-    usePipelineDebugStore.getState().setFilteredTerms(0.4, [term])
+    usePipelineDebugStore.getState().setFilteredTerms(0.4, [term], [])
     usePipelineDebugStore.getState().setBubbleTerms([term])
     const state = usePipelineDebugStore.getState()
     expect(state.filteredThreshold).toBe(0.4)
-    expect(state.filteredTerms[0]?.word).toBe('React')
+    expect(state.filteredPassedTerms[0]?.word).toBe('React')
+    expect(state.filteredRejectedTerms).toHaveLength(0)
     expect(state.bubbleTerms[0]?.word).toBe('React')
   })
 })

--- a/Frontend/src/stores/__tests__/termStore.test.ts
+++ b/Frontend/src/stores/__tests__/termStore.test.ts
@@ -57,7 +57,7 @@ describe('termStore', () => {
     expect(Object.keys(state.termTimestamps)).toHaveLength(1)
   })
 
-  it('maxVisibleTerms 上限を超える追加は抑制される', () => {
+  it('maxVisibleTerms 上限到達時は最古の非スター語を入れ替える', () => {
     useTermMapWindowSettingsStore.getState().setMaxVisibleTerms(5)
     useTermStore.getState().addTerms([
       makeTerm('a'),
@@ -65,9 +65,9 @@ describe('termStore', () => {
       makeTerm('c'),
       makeTerm('d'),
       makeTerm('e'),
-      makeTerm('f'),
     ])
-    expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual(['a', 'b', 'c', 'd', 'e'])
+    useTermStore.getState().addTerms([makeTerm('f')])
+    expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual(['b', 'c', 'd', 'e', 'f'])
   })
 
   it('表示枠がスターで埋まっている場合は新規追加しない', () => {
@@ -84,6 +84,20 @@ describe('termStore', () => {
     }
     useTermStore.getState().addTerms([makeTerm('extra')])
     expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual(['p1', 'p2', 'p3', 'p4', 'p5'])
+  })
+
+  it('スター語は残して非スター語を優先的に置き換える', () => {
+    useTermMapWindowSettingsStore.getState().setMaxVisibleTerms(5)
+    useTermStore.getState().addTerms([
+      makeTerm('a'),
+      makeTerm('b'),
+      makeTerm('c'),
+      makeTerm('d'),
+      makeTerm('e'),
+    ])
+    useTermStore.getState().togglePin('a')
+    useTermStore.getState().addTerms([makeTerm('f')])
+    expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual(['a', 'c', 'd', 'e', 'f'])
   })
 
   it('updateTermScore で対象のスコアを更新できる', () => {

--- a/Frontend/src/stores/pipelineDebugStore.ts
+++ b/Frontend/src/stores/pipelineDebugStore.ts
@@ -14,6 +14,7 @@ export interface DebugFilteredTerm {
   id: string
   word: string
   score: number
+  passed: boolean
 }
 
 type LayerKey = 'sent' | 'sse' | 'filtered' | 'bubble'
@@ -22,13 +23,14 @@ interface PipelineDebugState {
   sentInputs: string[]
   sseTerms: DebugSseTerm[]
   filteredThreshold: number
-  filteredTerms: DebugFilteredTerm[]
+  filteredPassedTerms: DebugFilteredTerm[]
+  filteredRejectedTerms: DebugFilteredTerm[]
   bubbleTerms: DebugFilteredTerm[]
   visibleLayers: Record<LayerKey, boolean>
   pushSentInput: (text: string) => void
   pushSseRows: (rows: TermRow[]) => void
   setFilteredThreshold: (threshold: number) => void
-  setFilteredTerms: (threshold: number, terms: Term[]) => void
+  setFilteredTerms: (threshold: number, passedTerms: Term[], rejectedTerms: Term[]) => void
   setBubbleTerms: (terms: Term[]) => void
   toggleLayer: (layer: LayerKey) => void
   clearAll: () => void
@@ -43,7 +45,8 @@ export const usePipelineDebugStore = create<PipelineDebugState>((set) => ({
   sentInputs: [],
   sseTerms: [],
   filteredThreshold: 0.1,
-  filteredTerms: [],
+  filteredPassedTerms: [],
+  filteredRejectedTerms: [],
   bubbleTerms: [],
   visibleLayers: {
     sent: true,
@@ -71,12 +74,19 @@ export const usePipelineDebugStore = create<PipelineDebugState>((set) => ({
     filteredThreshold: threshold,
   }),
 
-  setFilteredTerms: (threshold, terms) => set({
+  setFilteredTerms: (threshold, passedTerms, rejectedTerms) => set({
     filteredThreshold: threshold,
-    filteredTerms: keepRecent(terms.map((term) => ({
+    filteredPassedTerms: keepRecent(passedTerms.map((term) => ({
       id: term.id,
       word: term.word,
       score: term.score,
+      passed: true,
+    }))),
+    filteredRejectedTerms: keepRecent(rejectedTerms.map((term) => ({
+      id: term.id,
+      word: term.word,
+      score: term.score,
+      passed: false,
     }))),
   }),
 
@@ -85,6 +95,7 @@ export const usePipelineDebugStore = create<PipelineDebugState>((set) => ({
       id: term.id,
       word: term.word,
       score: term.score,
+      passed: true,
     }))),
   }),
 
@@ -98,7 +109,8 @@ export const usePipelineDebugStore = create<PipelineDebugState>((set) => ({
   clearAll: () => set({
     sentInputs: [],
     sseTerms: [],
-    filteredTerms: [],
+    filteredPassedTerms: [],
+    filteredRejectedTerms: [],
     bubbleTerms: [],
   }),
 }))

--- a/Frontend/src/stores/termStore.ts
+++ b/Frontend/src/stores/termStore.ts
@@ -35,31 +35,52 @@ export const useTermStore = create<TermState>((set) => ({
   addTerms: (terms) => set((state) => {
     const now = Date.now()
     const maxVisibleTerms = useTermMapWindowSettingsStore.getState().maxVisibleTerms
-    const pinnedCount = state.activeTerms.filter((term) => state.pinnedTermIds.has(term.id)).length
-    if (state.activeTerms.length >= maxVisibleTerms && pinnedCount >= maxVisibleTerms) {
-      return state
-    }
-    const availableSlots = Math.max(0, maxVisibleTerms - state.activeTerms.length)
-    if (availableSlots <= 0) {
-      return state
+    const existingIds = new Set(state.activeTerms.map((term) => term.id))
+    const nextActiveTerms = [...state.activeTerms]
+    const nextTermTimestamps = { ...state.termTimestamps }
+
+    const findOldestRemovableId = (): string | null => {
+      let oldestId: string | null = null
+      let oldestTs = Number.POSITIVE_INFINITY
+      for (const term of nextActiveTerms) {
+        if (state.pinnedTermIds.has(term.id)) continue
+        const ts = nextTermTimestamps[term.id] ?? 0
+        if (ts < oldestTs) {
+          oldestTs = ts
+          oldestId = term.id
+        }
+      }
+      return oldestId
     }
 
-    const existingIds = new Set(state.activeTerms.map(t => t.id))
-    const newTerms: Term[] = []
-    const nextTermTimestamps = { ...state.termTimestamps }
     for (const t of terms) {
-      if (newTerms.length >= availableSlots) break
-      if (!existingIds.has(t.id)) {
-        existingIds.add(t.id)
-        nextTermTimestamps[t.id] = now
-        newTerms.push({
-          ...t,
-          category: normalizeTermCategory(t.category),
-        })
+      if (existingIds.has(t.id)) continue
+
+      while (nextActiveTerms.length >= maxVisibleTerms) {
+        const removableId = findOldestRemovableId()
+        if (!removableId) {
+          return {
+            activeTerms: nextActiveTerms,
+            termTimestamps: nextTermTimestamps,
+          }
+        }
+        const removeIdx = nextActiveTerms.findIndex((term) => term.id === removableId)
+        if (removeIdx >= 0) nextActiveTerms.splice(removeIdx, 1)
+        delete nextTermTimestamps[removableId]
+        existingIds.delete(removableId)
       }
+
+      const normalized: Term = {
+        ...t,
+        category: normalizeTermCategory(t.category),
+      }
+      nextActiveTerms.push(normalized)
+      nextTermTimestamps[normalized.id] = now
+      existingIds.add(normalized.id)
     }
+
     return {
-      activeTerms: [...state.activeTerms, ...newTerms],
+      activeTerms: nextActiveTerms,
       termTimestamps: nextTermTimestamps,
     }
   }),


### PR DESCRIPTION
## Summary
- SSE可視化の送信ログを EventSource `onopen` 起点に変更し、実送信タイミングと同期
- フィルター結果を「通過 / 除外」に分けて表示し、`partitionByScore` で閾値比較ロジックを統一
- バブル生成上限到達時は最古の非スター語を入れ替えて新規追加し、全枠スター時のみ追加停止

## Test plan
- [x] `cd Frontend && bun test src/stores/__tests__/pipelineDebugStore.test.ts src/infrastructure/adapters/__tests__/ScoreThresholdFilter.test.ts src/stores/__tests__/termStore.test.ts src/stores/__tests__/termMapWindowSettingsStore.test.ts src/infrastructure/adapters src/presentation/utils/__tests__/importanceRanking.test.ts src/presentation/hooks/__tests__/transcriptionModeSync.test.ts`
- [x] `cd Frontend && bun run build`

Made with [Cursor](https://cursor.com)