### PR TITLE
feat: 非UIトリガーの時系列ログウィンドウを追加

### DIFF
--- a/Frontend/docs/orders/order-004.md
+++ b/Frontend/docs/orders/order-004.md
@@ -1,0 +1,52 @@
+# order-004: 時系列トリガーログウィンドウの追加とMarkdownコピー対応
+
+## 日付
+
+2026-05-29
+
+## 参加者
+
+- ユーザー（担当者）
+- Codex
+
+---
+
+## 指示要約
+
+本番環境で利用できるテストツールとして、UIボタン以外のイベント発生タイミングを可視化する新規ウィンドウを追加する。
+
+- 文字起こし文が確定したタイミング
+- 上記文がサーバーへ送信されたタイミング
+- SSEを受信したタイミング
+- フィルタリング完了タイミング
+- バブル生成タイミング
+
+加えて、SSE可視化ウィンドウ同様にチェックボックスで表示/非表示を切り替えられること、表示中全項目コピー・項目別コピーをMarkdown形式で行えることを求める。
+
+---
+
+## 実装方針
+
+1. `ReferDictScoreSseBridge` に各トリガーのログ記録ポイントを集約する。
+2. 画面描画用に `triggerTimelineStore` を追加し、ログ配列と表示フラグを管理する。
+3. 新規ウィンドウ `TriggerTimelineWindow` を `windows` レジストリへ登録する。
+4. コピー機能は `navigator.clipboard.writeText` を用い、以下2系統を実装する。
+   - 表示中の全項目をMarkdownコピー
+   - 各項目セクション単体をMarkdownコピー
+
+---
+
+## 変更ファイル
+
+- `Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx`
+- `Frontend/src/presentation/windows/index.ts`
+- `Frontend/src/presentation/windows/TriggerTimelineWindow/index.tsx`（新規）
+- `Frontend/src/stores/triggerTimelineStore.ts`（新規）
+- `Frontend/src/stores/__tests__/triggerTimelineStore.test.ts`（新規）
+
+---
+
+## 補足
+
+- UIボタン操作ログは対象外とし、非UIトリガーのみを記録する。
+- ログ表示時刻はミリ秒まで表示し、時系列確認を優先した。

--- a/Frontend/docs/tests/test-spec-016.md
+++ b/Frontend/docs/tests/test-spec-016.md
@@ -1,0 +1,47 @@
+# test-spec-016: 時系列トリガーログウィンドウ検証
+
+## 日付
+
+2026-05-29
+
+## 対象ファイル
+
+- `Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx`
+- `Frontend/src/presentation/windows/TriggerTimelineWindow/index.tsx`
+- `Frontend/src/presentation/windows/index.ts`
+- `Frontend/src/stores/triggerTimelineStore.ts`
+- `Frontend/src/stores/__tests__/triggerTimelineStore.test.ts`
+
+## テストの目的
+
+本番で有効なテスト支援ウィンドウとして、非UIトリガーの時系列ログが収集・表示・コピーできることを確認する。
+
+- 必須5イベント（確定/送信/SSE受信/フィルタ/バブル生成）が記録される
+- チェックボックスで項目の表示/非表示を切り替えられる
+- 表示中全項目コピーと項目別コピーがMarkdownで動作する
+
+## テスト項目
+
+| # | テストケース | 種別 | 期待結果 |
+|---|---|---|---|
+| 1 | `appendLog` | 単体 | ログが追加され、`occurredAt` が設定される |
+| 2 | `toggleType` | 単体 | 表示フラグがON/OFF切り替わる |
+| 3 | `clearLogs` | 単体 | ログ配列が空になる |
+| 4 | SSEブリッジ連携 | 実装確認 | 必須5イベントが `triggerTimelineStore` へ送られる |
+| 5 | 全体コピー | 実装確認 | 表示中項目のみをMarkdownとしてクリップボードへ書き込む |
+| 6 | 項目別コピー | 実装確認 | 選択項目のみをMarkdownとしてコピーできる |
+
+## 実行結果
+
+### 実行コマンド
+
+```bash
+cd Frontend
+bun test src/stores/__tests__/pipelineDebugStore.test.ts src/stores/__tests__/triggerTimelineStore.test.ts
+npm run build
+```
+
+| コマンド | 結果 | メモ |
+|----------|------|------|
+| `bun test ...` | 合格 | 8件成功、0件失敗 |
+| `npm run build` | 合格 | `tsc -b && vite build` 成功（bundle size warningのみ） |

--- a/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
+++ b/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
@@ -9,6 +9,7 @@ import {
 import { defaultScoreUpdateStrategy } from '../../infrastructure/adapters/DefaultScoreUpdateStrategy'
 import { FrequencyScoreAdapter } from '../../infrastructure/adapters/FrequencyScoreAdapter'
 import { usePipelineDebugStore } from '../../stores/pipelineDebugStore'
+import { useTriggerTimelineStore } from '../../stores/triggerTimelineStore'
 
 interface ReferDictScoreSseBridgeProps {
   scoreThreshold?: number
@@ -28,8 +29,19 @@ export const ReferDictScoreSseBridge: React.FC<ReferDictScoreSseBridgeProps> = (
   }
 
   useEffect(() => {
-    const unsub = useTermStore.subscribe((state) => {
+    const unsub = useTermStore.subscribe((state, prev) => {
       usePipelineDebugStore.getState().setBubbleTerms(state.activeTerms)
+      const currentSignature = state.activeTerms.map((term) => `${term.id}:${term.score.toFixed(4)}`).join('|')
+      const prevSignature = prev.activeTerms.map((term) => `${term.id}:${term.score.toFixed(4)}`).join('|')
+      if (state.activeTerms.length === 0 || currentSignature === prevSignature) return
+      const labels = state.activeTerms.slice(0, 4).map((term) => term.word).join(' / ')
+      useTriggerTimelineStore.getState().appendLog({
+        type: 'bubbleCreated',
+        summary: `${state.activeTerms.length}件のバブルを表示`,
+        detail: labels
+          ? `生成対象: ${labels}${state.activeTerms.length > 4 ? ' ...' : ''}`
+          : 'バブル表示対象を更新しました。',
+      })
     })
     return unsub
   }, [])
@@ -46,15 +58,38 @@ export const ReferDictScoreSseBridge: React.FC<ReferDictScoreSseBridgeProps> = (
   }, [])
 
   useReferDictScoreSse({
+    onBeforeSend: (text) => {
+      useTriggerTimelineStore.getState().appendLog({
+        type: 'transcriptFinalized',
+        summary: '文字起こし文を確定',
+        detail: text,
+      })
+    },
     onRequestOpened: (text) => {
       usePipelineDebugStore.getState().pushSentInput(text)
+      useTriggerTimelineStore.getState().appendLog({
+        type: 'sentToServer',
+        summary: '確定文をサーバーへ送信',
+        detail: text,
+      })
     },
     onChunk: (rows) => {
       usePipelineDebugStore.getState().pushSseRows(rows)
+      const preview = rows.slice(0, 4).map((row) => `${row.term}(${row.score.toFixed(2)})`).join(' / ')
+      useTriggerTimelineStore.getState().appendLog({
+        type: 'sseReceived',
+        summary: `SSEで${rows.length}件を受信`,
+        detail: preview || '受信データのプレビューなし',
+      })
     },
     onTerms: (terms) => {
       const { passed, rejected } = partitionByScore(terms, threshold)
       usePipelineDebugStore.getState().setFilteredTerms(threshold, passed, rejected)
+      useTriggerTimelineStore.getState().appendLog({
+        type: 'filtered',
+        summary: `フィルタ完了（通過${passed.length} / 除外${rejected.length}）`,
+        detail: `閾値 ${threshold.toFixed(4)} で評価`,
+      })
       const adapted = adapterRef.current?.adapt(passed)
       if (!adapted) return
       const store = useTermStore.getState()

--- a/Frontend/src/presentation/windows/TriggerTimelineWindow/index.tsx
+++ b/Frontend/src/presentation/windows/TriggerTimelineWindow/index.tsx
@@ -1,0 +1,198 @@
+import React, { useCallback, useMemo } from 'react'
+import type { WindowProps } from '../IWindowDefinition'
+import { toast } from 'sonner'
+import {
+  useTriggerTimelineStore,
+  type TriggerTimelineEntry,
+  type TriggerTimelineType,
+} from '../../../stores/triggerTimelineStore'
+
+const typeLabels: Record<TriggerTimelineType, string> = {
+  transcriptFinalized: '1) 文字起こし確定',
+  sentToServer: '2) サーバー送信',
+  sseReceived: '3) SSE受信',
+  filtered: '4) フィルタリング完了',
+  bubbleCreated: '5) バブル生成',
+}
+
+const orderedTypes: TriggerTimelineType[] = [
+  'transcriptFinalized',
+  'sentToServer',
+  'sseReceived',
+  'filtered',
+  'bubbleCreated',
+]
+
+function formatOccurredAt(value: number): string {
+  const date = new Date(value)
+  const base = new Intl.DateTimeFormat('ja-JP', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(date)
+  const ms = String(date.getMilliseconds()).padStart(3, '0')
+  return `${base}.${ms}`
+}
+
+function escapeMarkdown(value: string): string {
+  return value.replace(/\|/g, '\\|')
+}
+
+function buildTypeMarkdown(type: TriggerTimelineType, entries: TriggerTimelineEntry[]): string {
+  const lines = [
+    `## ${typeLabels[type]} (${entries.length})`,
+    '',
+  ]
+  if (entries.length === 0) {
+    lines.push('- 記録なし')
+  } else {
+    for (const entry of entries) {
+      lines.push(`- **${formatOccurredAt(entry.occurredAt)}** ${escapeMarkdown(entry.summary)}`)
+      lines.push(`  - ${escapeMarkdown(entry.detail)}`)
+    }
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+export const TriggerTimelineWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
+  const dk = darkMode
+  const logs = useTriggerTimelineStore((s) => s.logs)
+  const visibleTypes = useTriggerTimelineStore((s) => s.visibleTypes)
+  const toggleType = useTriggerTimelineStore((s) => s.toggleType)
+  const clearLogs = useTriggerTimelineStore((s) => s.clearLogs)
+
+  const logsByType = useMemo(() => {
+    const grouped: Record<TriggerTimelineType, TriggerTimelineEntry[]> = {
+      transcriptFinalized: [],
+      sentToServer: [],
+      sseReceived: [],
+      filtered: [],
+      bubbleCreated: [],
+    }
+    for (const entry of logs) {
+      grouped[entry.type].push(entry)
+    }
+    for (const key of Object.keys(grouped) as TriggerTimelineType[]) {
+      grouped[key].sort((a, b) => b.occurredAt - a.occurredAt)
+    }
+    return grouped
+  }, [logs])
+
+  const copyMarkdown = useCallback(async (content: string, successMessage: string) => {
+    try {
+      await navigator.clipboard.writeText(content)
+      toast.success(successMessage)
+    } catch {
+      toast.error('コピーに失敗しました')
+    }
+  }, [])
+
+  const copyAllVisibleAsMarkdown = useCallback(() => {
+    const visibleOrderedTypes = orderedTypes.filter((type) => visibleTypes[type])
+    const sections = visibleOrderedTypes.map((type) => buildTypeMarkdown(type, logsByType[type]))
+    const markdown = [
+      '# 時系列トリガーログ',
+      '',
+      `- 出力時刻: ${new Date().toISOString()}`,
+      '',
+      ...sections,
+    ].join('\n')
+    void copyMarkdown(markdown, '表示中の項目をMarkdownでコピーしました')
+  }, [copyMarkdown, logsByType, visibleTypes])
+
+  const copySingleTypeAsMarkdown = useCallback((type: TriggerTimelineType) => {
+    const markdown = [
+      '# 時系列トリガーログ',
+      '',
+      buildTypeMarkdown(type, logsByType[type]),
+    ].join('\n')
+    void copyMarkdown(markdown, `「${typeLabels[type]}」をMarkdownでコピーしました`)
+  }, [copyMarkdown, logsByType])
+
+  return (
+    <div className={`h-full overflow-auto p-3 ${dk ? 'bg-[#0d0e1a] text-slate-200' : 'bg-white text-slate-700'}`}>
+      <div className={`mb-3 rounded border p-2 ${dk ? 'border-slate-700 bg-slate-900/40' : 'border-slate-200 bg-slate-50'}`}>
+        <div className="mb-2 flex flex-wrap items-center gap-2">
+          {orderedTypes.map((type) => (
+            <label
+              key={type}
+              className={`inline-flex items-center gap-1 rounded border px-2 py-1 text-[11px] ${
+                visibleTypes[type]
+                  ? (dk ? 'border-emerald-400 text-emerald-300' : 'border-emerald-600 text-emerald-700')
+                  : (dk ? 'border-slate-600 text-slate-400' : 'border-slate-300 text-slate-500')
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={visibleTypes[type]}
+                onChange={() => toggleType(type)}
+                className="size-3.5"
+              />
+              <span>{typeLabels[type]}</span>
+            </label>
+          ))}
+          <button
+            type="button"
+            onClick={copyAllVisibleAsMarkdown}
+            className={`rounded border px-2 py-1 text-[11px] ${dk ? 'border-cyan-500/50 text-cyan-200 hover:bg-cyan-500/10' : 'border-cyan-300 text-cyan-700 hover:bg-cyan-50'}`}
+          >
+            表示中をMarkdownコピー
+          </button>
+          <button
+            type="button"
+            onClick={clearLogs}
+            className={`rounded border px-2 py-1 text-[11px] ${dk ? 'border-slate-600 text-slate-300' : 'border-slate-300 text-slate-600'}`}
+          >
+            ログをクリア
+          </button>
+        </div>
+        <p className={`text-[11px] ${dk ? 'text-slate-400' : 'text-slate-500'}`}>
+          UIボタン以外のトリガーを時系列で記録します。イベントごとに「何が・いつ・どうなったか」を確認できます。
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {orderedTypes
+          .filter((type) => visibleTypes[type])
+          .map((type) => {
+            const entries = logsByType[type]
+            return (
+              <section key={type} className={`rounded border p-2 ${dk ? 'border-slate-700 bg-slate-900/30' : 'border-slate-200 bg-slate-50/70'}`}>
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <h3 className="text-xs font-bold">
+                    {typeLabels[type]} ({entries.length})
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={() => copySingleTypeAsMarkdown(type)}
+                    className={`rounded border px-2 py-1 text-[11px] ${dk ? 'border-cyan-500/40 text-cyan-200 hover:bg-cyan-500/10' : 'border-cyan-300 text-cyan-700 hover:bg-cyan-50'}`}
+                  >
+                    この項目をコピー
+                  </button>
+                </div>
+                {entries.length === 0 ? (
+                  <p className="text-[11px] opacity-60">まだ記録がありません</p>
+                ) : (
+                  <ul className="space-y-2">
+                    {entries.map((entry) => (
+                      <li key={entry.id} className={`rounded border px-2 py-1.5 text-[11px] ${dk ? 'border-slate-700/80 bg-slate-950/35' : 'border-slate-200 bg-white/90'}`}>
+                        <div className="flex items-start justify-between gap-2">
+                          <span className="font-semibold">{entry.summary}</span>
+                          <time className={`shrink-0 font-mono ${dk ? 'text-slate-400' : 'text-slate-500'}`}>
+                            {formatOccurredAt(entry.occurredAt)}
+                          </time>
+                        </div>
+                        <p className={`mt-1 leading-snug ${dk ? 'text-slate-300' : 'text-slate-600'}`}>{entry.detail}</p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            )
+          })}
+      </div>
+    </div>
+  )
+}

--- a/Frontend/src/presentation/windows/index.ts
+++ b/Frontend/src/presentation/windows/index.ts
@@ -7,6 +7,7 @@ import { MinutesWindow } from './MinutesWindow'
 import { ImportanceRankingWindow } from './ImportanceRankingWindow'
 import { SystemControlWindow } from './SystemControlWindow'
 import { PipelineDebugWindow } from './PipelineDebugWindow'
+import { TriggerTimelineWindow } from './TriggerTimelineWindow'
 import { SYSTEM_CONTROL_WINDOW_ID } from '../constants/systemControlWindow'
 
 export function registerAllWindows(): void {
@@ -23,6 +24,7 @@ export function registerAllWindows(): void {
   registerWindow({ id: 'importanceRanking', label: '重要度',  component: ImportanceRankingWindow })
   registerWindow({ id: 'minutes',       label: '議事録',      component: MinutesWindow })
   registerWindow({ id: 'pipelineDebug', label: 'SSE可視化',   component: PipelineDebugWindow })
+  registerWindow({ id: 'triggerTimeline', label: '時系列トリガー', component: TriggerTimelineWindow })
 }
 
 export * from './registry'

--- a/Frontend/src/stores/__tests__/triggerTimelineStore.test.ts
+++ b/Frontend/src/stores/__tests__/triggerTimelineStore.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { useTriggerTimelineStore } from '../triggerTimelineStore'
+
+describe('triggerTimelineStore', () => {
+  beforeEach(() => {
+    useTriggerTimelineStore.getState().clearLogs()
+  })
+
+  it('トリガーログを追加できる', () => {
+    useTriggerTimelineStore.getState().appendLog({
+      type: 'transcriptFinalized',
+      summary: '文字起こし文を確定',
+      detail: 'Reactについて説明します。',
+    })
+
+    const state = useTriggerTimelineStore.getState()
+    expect(state.logs).toHaveLength(1)
+    expect(state.logs[0]?.type).toBe('transcriptFinalized')
+    expect(state.logs[0]?.occurredAt).toBeGreaterThan(0)
+  })
+
+  it('表示項目をチェックボックス向けに切り替えられる', () => {
+    useTriggerTimelineStore.getState().toggleType('sseReceived')
+    expect(useTriggerTimelineStore.getState().visibleTypes.sseReceived).toBe(false)
+  })
+
+  it('clearLogsで時系列ログを空にできる', () => {
+    useTriggerTimelineStore.getState().appendLog({
+      type: 'bubbleCreated',
+      summary: 'バブル表示を更新',
+      detail: 'Node.js / TypeScript',
+    })
+    useTriggerTimelineStore.getState().clearLogs()
+    expect(useTriggerTimelineStore.getState().logs).toEqual([])
+  })
+})

--- a/Frontend/src/stores/triggerTimelineStore.ts
+++ b/Frontend/src/stores/triggerTimelineStore.ts
@@ -1,0 +1,68 @@
+import { create } from 'zustand'
+
+const MAX_LOGS = 200
+
+export type TriggerTimelineType =
+  | 'transcriptFinalized'
+  | 'sentToServer'
+  | 'sseReceived'
+  | 'filtered'
+  | 'bubbleCreated'
+
+export interface TriggerTimelineEntry {
+  id: string
+  type: TriggerTimelineType
+  summary: string
+  detail: string
+  occurredAt: number
+}
+
+interface TriggerTimelineState {
+  logs: TriggerTimelineEntry[]
+  visibleTypes: Record<TriggerTimelineType, boolean>
+  appendLog: (entry: Omit<TriggerTimelineEntry, 'id' | 'occurredAt'>) => void
+  toggleType: (type: TriggerTimelineType) => void
+  clearLogs: () => void
+}
+
+function keepRecent<T>(items: T[]): T[] {
+  if (items.length <= MAX_LOGS) return items
+  return items.slice(items.length - MAX_LOGS)
+}
+
+function createId(type: TriggerTimelineType): string {
+  return `${type}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+export const useTriggerTimelineStore = create<TriggerTimelineState>((set) => ({
+  logs: [],
+  visibleTypes: {
+    transcriptFinalized: true,
+    sentToServer: true,
+    sseReceived: true,
+    filtered: true,
+    bubbleCreated: true,
+  },
+
+  appendLog: (entry) => set((state) => ({
+    logs: keepRecent([
+      ...state.logs,
+      {
+        ...entry,
+        id: createId(entry.type),
+        occurredAt: Date.now(),
+      },
+    ]),
+  })),
+
+  toggleType: (type) => set((state) => ({
+    visibleTypes: {
+      ...state.visibleTypes,
+      [type]: !state.visibleTypes[type],
+    },
+  })),
+
+  clearLogs: () => set({
+    logs: [],
+  }),
+}))


### PR DESCRIPTION
## Summary
- 非UIトリガー（文字起こし確定 / サーバー送信 / SSE受信 / フィルタ完了 / バブル生成）を時系列で記録する `時系列トリガー` ウィンドウを追加
- チェックボックスによる表示制御と、表示中全体コピー・項目別コピーのMarkdown出力を実装
- `triggerTimelineStore` の単体テストを追加し、order/test-specドキュメントを更新

## Test plan
- [x] `cd Frontend && bun test src/stores/__tests__/pipelineDebugStore.test.ts src/stores/__tests__/triggerTimelineStore.test.ts`
- [x] `cd Frontend && npm run build`

Made with [Cursor](https://cursor.com)