### PR TITLE
fix(frontend): 重要単語辞書とバブル表示枠を分離（order-013）

### DIFF
--- a/Frontend/docs/orders/order-013.md
+++ b/Frontend/docs/orders/order-013.md
@@ -1,0 +1,253 @@
+# order-013: 重要単語辞書とバブル表示状態の分離・パフォーマンス上限の決定
+
+## 日付
+
+2026-05-28（初版） / 2026-05-29（現行コードに合わせて改訂）
+
+## 参加者
+
+- ユーザー（担当者）
+- Claude（初版）
+- Codex（改訂・妥当性レビュー）
+
+## 関連ドキュメント
+
+| ドキュメント | 関係 |
+|---|---|
+| `order-003.md` Step 6 | バブル削除を `termStore` + `useBubbleLifecycle` で実装済み（**本オーダーで設計を修正**） |
+| `test-spec-015.md` | Step 6 の検証記録（実装変更後は追補または新 spec が必要） |
+| `ADR-007` 等 | グローバルリセット時の `bubbleStore.clearBubbles()` は既に配線済み |
+
+---
+
+## 概要
+
+Step 6 実装後に発覚した「バブル上限がランキング・文字起こしまで縮む」不具合の原因分析と修正方針、および重要単語辞書（`termStore.activeTerms`）のパフォーマンス上限の調査結果をまとめる。
+
+**本オーダーは新機能追加ではなく、Step 6 の責務分離リファクタリングである。**
+
+---
+
+## 現状コードの整理（2026-05-29 時点）
+
+| コンポーネント | 実際の状態 |
+|---|---|
+| `useBubbleLifecycle` | `App.tsx` でマウント済み。1 秒ごとに **`termStore.removeTermById`** を呼ぶ（バグの直接原因） |
+| `bubbleStore` | **存在・部分接続**。`clearBubbles` はリセット / フェーズ遷移で使用。**表示には未使用** |
+| `bubbleStore.pruneExpired` | 実装あるが **未呼び出し** |
+| `BubbleCloudWindow` | `termStore.activeTerms` をそのまま `BubbleCloud` に渡している |
+| `termStore.addTerms` | `maxVisibleTerms`（バブル設定 5〜30）到達時に **辞書から最古の非スター語を追い出す**（別経路の同種バグ） |
+| `ReferDictScoreSseBridge` | `addTerms` / `updateTermScore` のみ。`bubbleStore` には触れない |
+
+初版の「`bubbleStore` は未接続」は **不正確**。未接続なのは **バブル表示パス** であり、ストア自体はリセット系で使われている。
+
+---
+
+## バグ報告
+
+### 現象
+
+- バブルのライフタイム（`useBubbleLifecycle`）により `termStore.removeTermById` が走ると、`ImportanceRankingWindow` と `TranscriptionWindow` からも同じ単語が消える
+- バブル上限（`maxVisibleTerms` 5〜30）が、**辞書追加時**（`addTerms` の入れ替え）と **ライフタイム削除** の両方でランキング・文字起こしの件数に影響する
+
+### 根本原因
+
+```
+termStore.activeTerms（1 つの配列＝セッション辞書）
+  ├─ BubbleCloudWindow      … 全件表示（本来は表示枠だけ絞るべき）
+  ├─ ImportanceRankingWindow … 全件参照
+  └─ TranscriptionWindow    … 全件マーキング
+
+削除経路 A: useBubbleLifecycle → removeTermById()
+削除経路 B: addTerms() が maxVisibleTerms 超過で最古語を splice 削除
+  └─ いずれも辞書から消える → 全ウィンドウから消える
+```
+
+**「セッション中の重要単語辞書」と「バブルに出す表示枠」が同じ `activeTerms` と同じ上限設定で管理されている**ことが原因。
+
+### 用語の整理
+
+| 用語 | 意味 |
+|---|---|
+| 辞書 | `termStore.activeTerms`。セッション中は **ライフタイムでは削除しない**（リセット・デモ除去・明示 API のみ） |
+| 表示枠 | バブルに載せる ID 集合。件数上限・5 秒猶予・即時溢れ削除は **こちらだけ** に適用 |
+
+---
+
+## 修正方針
+
+### 決定: `bubbleStore` に表示対象 ID のみ持たせる（Term コピーは持たない）
+
+`bubbleStore` の `bubbles: Bubble[]` をやめ、**表示対象の termId とバブル用タイムスタンプ**だけを管理する。スコア更新は `termStore.updateTermScore` の 1 箇所に集約する。
+
+#### データ構造（目標）
+
+```
+termStore.activeTerms + termTimestamps
+  ├─ ImportanceRankingWindow  … 変更なし（辞書全件）
+  ├─ TranscriptionWindow      … 変更なし（辞書全件）
+  └─ スコア更新・ピン・履歴   … 変更なし
+
+bubbleStore
+  visibleTermIds: string[]          … 表示対象（順序は timestamps で決める）
+  bubbleTimestamps: Record<id, ms>  … 追加時刻（溢れ・猶予判定用）
+  └─ BubbleCloudWindow
+        activeTerms.filter(t => visibleTermIds.includes(t.id))
+```
+
+> **実装メモ:** Zustand の state に `Set` をそのまま置くとイミュータブル更新でハマりやすい。`string[]` + `includes`、または更新時に毎回 `new Set(...)` する方針を推奨する。
+
+#### データフロー（目標）
+
+```
+SSE 受信（ReferDictScoreSseBridge.onTerms）
+  ├─ termStore.addTerms()              … 辞書へ追加（上限による追い出しは行わない）
+  ├─ termStore.updateTermScore()       … 既存語のスコア更新
+  └─ bubbleStore.addVisibleTermId()    … 新規追加語のみ表示枠へ（toAdd 分）
+
+1 秒ごと（useBubbleLifecycle を書き換え）
+  ├─ hardLimit / softLimit ← termMapWindowSettingsStore.maxVisibleTerms
+  ├─ 溢れ・5 秒猶予・ピン留め除外 ← bubbleStore 上で実施
+  └─ termStore.removeTermById は呼ばない
+
+クリック・頻度加算
+  └─ termStore.updateTermScore() のみ
+
+グローバルリセット / 発表終了
+  ├─ termStore.resetSession()（既存）
+  └─ bubbleStore.clearVisible()（API 名は実装時に統一）
+```
+
+#### Term コピーを `bubbleStore` に持たせない理由
+
+`updateTermScore` が `termStore` と `bubbleStore` の両方を更新する必要が生じ、同期ズレのリスクがあるため不採用（初版方針を維持）。
+
+#### `termStore.addTerms` の上限追い出しをやめる理由
+
+`maxVisibleTerms` は **バブル表示枠** の設定である。辞書側で同じ上限を適用すると、バブルを出していない語までランキング・文字起こしから消える。  
+追加時の `while (length >= maxVisibleTerms)` による splice 削除は **削除する**。
+
+辞書が無制限に伸びる懸念は「パフォーマンス上限」節のとおり、実運用規模では問題にならない想定。将来必要なら **辞書専用** のソフトリミットを別定数で切る（`maxVisibleTerms` とは別キー）。
+
+#### `useBubbleLifecycle` の扱い
+
+- **新規に `App.tsx` に prune 用 hook を足す案は採用しない**（既に `useBubbleLifecycle` が存在するため）
+- 中身を `bubbleStore` 操作に差し替え、death row 用 `useRef` はバブル ID 基準のまま流用可能
+- `pinnedTermIds` の除外・スター枠満了時の追加抑制は **表示枠側** で再現する（Step 6 仕様の維持）
+
+| Step 6 仕様 | 適用先（修正後） |
+|---|---|
+| `maxVisibleTerms`（5〜30） | `bubbleStore` の hardLimit |
+| `softLimit = min(20, hardLimit)` | `bubbleStore` |
+| 5 秒猶予（death row） | `useBubbleLifecycle` + `bubbleTimestamps` |
+| 非スター最古から即時削除（溢れ） | `bubbleStore` |
+| スター枠満了で新規を辞書に入れない | **`addTerms` では入れる** / **`addVisibleTermId` で表示だけ抑制**（決定済み） |
+
+> **決定（2026-05-29）:** スター枠満了時は **辞書には登録**し、**バブル表示枠だけ追加しない**（`addVisibleTermId` が `false` を返す）。
+
+---
+
+## 変更が必要なファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `src/stores/bubbleStore.ts` | `bubbles` 廃止 → `visibleTermIds` + `bubbleTimestamps`。`addVisibleTermId` / `removeVisibleTermId` / `clearVisible`（名称は実装で統一） |
+| `src/presentation/hooks/useBubbleLifecycle.ts` | `removeTermById` をやめ `bubbleStore` の溢れ・猶予処理に移す |
+| `src/stores/termStore.ts` | `addTerms` から `maxVisibleTerms` による追い出しを削除 |
+| `src/presentation/windows/BubbleCloudWindow/index.tsx` | 辞書を `visibleTermIds` でフィルタして `BubbleCloud` に渡す |
+| `src/presentation/components/ReferDictScoreSseBridge.tsx` | `toAdd` 後に `addVisibleTermId`（パスは `infrastructure/sse` から re-export） |
+| `src/presentation/App.tsx` | 変更は最小（リセットで `clearVisible` を呼ぶだけの可能性） |
+| `src/stores/__tests__/termStore.test.ts` | 辞書上限追い出しテストの期待値を修正 |
+| `src/stores/__tests__/bubbleStore.test.ts` | 新規または拡充（表示枠・prune・溢れ） |
+| `src/presentation/components/ReferDictScoreSseBridge.tsx` | デバッグ用 `setBubbleTerms` の購読元を表示枠ベースに変更（任意だが推奨） |
+
+**変更なし（ロジック面）:** `ImportanceRankingWindow` / `TranscriptionWindow`（辞書全件参照のまま）。
+
+**ドキュメント追従:** `test-spec-015.md` に改訂注記、または `test-spec-025.md` を新設。
+
+---
+
+## ライフタイム定数
+
+| 定数 | 値 | 適用先（修正後） |
+|---|---|---|
+| `MAX_BUBBLES` / hardLimit | `maxVisibleTerms`（設定 5〜30、既定 30） | `bubbleStore` + `useBubbleLifecycle` |
+| `SOFT_LIMIT` | `min(20, hardLimit)` | 同上 |
+| `SOFT_LIFESPAN_MS` | 5,000ms | 同上（`bubbleTimestamps` 基準） |
+
+`bubbleStore.ts` 内の固定 `30` / `20` は、設定値を読むよう **統合する**（二重定義を避ける）。
+
+---
+
+## 重要単語辞書のパフォーマンス上限
+
+### ボトルネック分析
+
+#### `updateTermScore`（最頻出）
+
+```typescript
+activeTerms: state.activeTerms.map(t =>
+  t.id === id ? { ...t, score } : t
+)
+```
+
+| 単語数 | map() 1回（目安） | 1秒に10回更新 |
+|---|---|---|
+| 500 | 〜0.01ms | 〜0.1ms/秒 |
+| 2,000 | 〜0.04ms | 〜0.4ms/秒 |
+| 5,000 | 〜0.1ms | 〜1ms/秒 |
+| 10,000 | 〜0.2ms | 〜2ms/秒 |
+
+計算コスト自体は問題になりにくい。
+
+#### Zustand 再レンダリング（実際の主ボトルネック）
+
+`updateTermScore` のたびに `activeTerms` の参照が変わり、購読コンポーネントが再レンダリング判定される。**呼び出し頻度**の影響が単語数より大きい。`ImportanceRankingWindow` は `useThrottledValue(160ms)` で緩和済み。
+
+#### ランキングのソート
+
+throttle あり。5,000 語でも 〜0.8ms 程度（目安）。
+
+### 実運用の単語数（目安）
+
+| セッション | 想定ユニーク語数 |
+|---|---|
+| 30分の発表 | 50〜150 |
+| 1時間の講義 | 100〜300 |
+| 3時間 | 200〜600 |
+
+### 決定事項
+
+| 項目 | 決定 |
+|---|---|
+| 辞書（`activeTerms`）の件数上限 | **ライフタイムでは設けない**。`addTerms` の `maxVisibleTerms` 追い出しは **廃止** |
+| 表示枠 | 既存 UI の `maxVisibleTerms`（5〜30）を **bubbleStore のみ** に適用 |
+| パフォーマンス上の余裕 | 辞書 2,000〜3,000 語程度までは現状の map 更新で十分な見込み |
+| 将来の保険 | 必要なら辞書専用ソフトリミット（500〜1,000）を **別設定** で検討。`maxVisibleTerms` と混同しない |
+
+---
+
+## 完了条件
+
+- [ ] バブル猶予・溢れ削除後も、ランキング・文字起こしに語が残る
+- [ ] `maxVisibleTerms` を下げても、辞書全件はランキングに反映される（表示枠のみ減る）
+- [ ] ピン留め語は表示枠の削除候補から除外される
+- [ ] グローバルリセットで辞書と表示枠の両方が空になる
+- [ ] `npm run build` および `termStore` / `bubbleStore` 関連単体テストが成功する
+
+---
+
+## 未決事項・保留
+
+- ブランチ名: `feature/bubble-store-separation` 等（`feature/bubble-lifecycle` は Step 6 完了済みのため流用しない方がよい）
+- ~~スター枠満了時~~ → **辞書登録・バブル非表示**（実装済み方針）
+- `visibleTermIds` 溢れ時の削除優先: **追加時刻が古い非スター語から**（現行 `bubbleStore.upsertBubble` と同様）
+- `removeTermById` API 自体はデモ除去等で残すか、使用箇所を grep して整理
+
+---
+
+## 次のアクション
+
+1. 本オーダーに沿ったブランチで `bubbleStore` リファクタ + `useBubbleLifecycle` 差し替え + `termStore.addTerms` 修正
+2. `test-spec-015` を改訂するか `test-spec-025` で「辞書は残る」回帰を追加
+3. 手動確認: 30 語超のセッションでバブルだけ減り、ランキング件数は減らないこと

--- a/Frontend/docs/tests/test-spec-025.md
+++ b/Frontend/docs/tests/test-spec-025.md
@@ -1,0 +1,35 @@
+# test-spec-025: order-013 辞書とバブル表示の分離
+
+## 日付
+
+2026-05-29
+
+## 関連オーダー
+
+- `order-013.md`
+
+## 対象ファイル
+
+- `Frontend/src/stores/bubbleStore.ts`
+- `Frontend/src/stores/termStore.ts`
+- `Frontend/src/presentation/hooks/useBubbleLifecycle.ts`
+- `Frontend/src/presentation/windows/BubbleCloudWindow/index.tsx`
+- `Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx`
+- `Frontend/src/stores/__tests__/bubbleStore.test.ts`
+- `Frontend/src/stores/__tests__/termStore.test.ts`
+
+## テスト項目
+
+| # | テストケース | 種別 | 期待結果 | 結果 |
+|---|---|---|---|---|
+| 1 | `termStore` 辞書上限 | 単体 | `maxVisibleTerms` 超過でも辞書から追い出さない | ✅ |
+| 2 | `termStore` スター枠満杯 | 単体 | 辞書には新規語を追加する | ✅ |
+| 3 | `bubbleStore` 表示枠入替 | 単体 | 上限時は最古の非スター語を入れ替える | ✅ |
+| 4 | `bubbleStore` スター枠満杯 | 単体 | 表示枠には追加しない（辞書は別ストア） | ✅ |
+| 5 | 回帰（ビルド） | ビルド | `npm run build` 成功 | ✅ |
+
+## 手動確認（推奨）
+
+1. SSE で 30 語超を受信し、バブルは上限付近で減るがランキング・文字起こしの語数は減らないこと
+2. 全バブルをスターにし、新規語がランキングに載るがバブルに出ないこと
+3. グローバルリセットで辞書と表示枠が両方空になること

--- a/Frontend/src/application/phase/PhaseUseCase.ts
+++ b/Frontend/src/application/phase/PhaseUseCase.ts
@@ -33,7 +33,7 @@ export class PhaseUseCase {
   }
 
   endPresentation(): void {
-    useBubbleStore.getState().clearBubbles()
+    useBubbleStore.getState().clearVisible()
     this.transitionTo('after')
   }
 }

--- a/Frontend/src/presentation/App.tsx
+++ b/Frontend/src/presentation/App.tsx
@@ -64,7 +64,7 @@ const App: React.FC = () => {
     svc.clearTranscript()
     useTranscriptStore.getState().clear()
     useTermStore.getState().resetSession()
-    useBubbleStore.getState().clearBubbles()
+    useBubbleStore.getState().clearVisible()
     toast.info('すべてのウィンドウをリセットしました')
   }, [demoStream])
 

--- a/Frontend/src/presentation/components/PhaseTransitionButton.tsx
+++ b/Frontend/src/presentation/components/PhaseTransitionButton.tsx
@@ -14,14 +14,14 @@ interface Props {
 export const PhaseTransitionButton: React.FC<Props> = ({ darkMode = true, compact = false, compactClassName = '' }) => {
   const currentPhaseId = usePhaseStore(s => s.currentPhaseId)
   const transitionTo = usePhaseStore(s => s.transitionTo)
-  const clearBubbles = useBubbleStore(s => s.clearBubbles)
+  const clearVisible = useBubbleStore(s => s.clearVisible)
   const dk = darkMode
 
   const isDuring = currentPhaseId === 'during'
 
   const handleClick = () => {
     if (isDuring) {
-      clearBubbles()
+      clearVisible()
       transitionTo('after')
     } else {
       transitionTo('during')

--- a/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
+++ b/Frontend/src/presentation/components/ReferDictScoreSseBridge.tsx
@@ -2,6 +2,7 @@ import type React from 'react'
 import { useEffect, useRef } from 'react'
 import { useReferDictScoreSse } from '../hooks/useReferDictScoreSse'
 import { useTermStore } from '../../stores/termStore'
+import { useBubbleStore } from '../../stores/bubbleStore'
 import {
   DEFAULT_SCORE_THRESHOLD,
   partitionByScore,
@@ -28,22 +29,41 @@ export const ReferDictScoreSseBridge: React.FC<ReferDictScoreSseBridgeProps> = (
     adapterRef.current = new FrequencyScoreAdapter(defaultScoreUpdateStrategy)
   }
 
+  const syncBubbleDebugTerms = () => {
+    const visibleSet = new Set(useBubbleStore.getState().visibleTermIds)
+    const bubbleTerms = useTermStore.getState().activeTerms.filter((term) => visibleSet.has(term.id))
+    usePipelineDebugStore.getState().setBubbleTerms(bubbleTerms)
+    return bubbleTerms
+  }
+
   useEffect(() => {
-    const unsub = useTermStore.subscribe((state, prev) => {
-      usePipelineDebugStore.getState().setBubbleTerms(state.activeTerms)
-      const currentSignature = state.activeTerms.map((term) => `${term.id}:${term.score.toFixed(4)}`).join('|')
-      const prevSignature = prev.activeTerms.map((term) => `${term.id}:${term.score.toFixed(4)}`).join('|')
-      if (state.activeTerms.length === 0 || currentSignature === prevSignature) return
-      const labels = state.activeTerms.slice(0, 4).map((term) => term.word).join(' / ')
+    const pushBubbleLog = (bubbleTerms: ReturnType<typeof syncBubbleDebugTerms>) => {
+      if (bubbleTerms.length === 0) return
+      const labels = bubbleTerms.slice(0, 4).map((term) => term.word).join(' / ')
       useTriggerTimelineStore.getState().appendLog({
         type: 'bubbleCreated',
-        summary: `${state.activeTerms.length}件のバブルを表示`,
+        summary: `${bubbleTerms.length}件のバブルを表示`,
         detail: labels
-          ? `生成対象: ${labels}${state.activeTerms.length > 4 ? ' ...' : ''}`
+          ? `生成対象: ${labels}${bubbleTerms.length > 4 ? ' ...' : ''}`
           : 'バブル表示対象を更新しました。',
       })
-    })
-    return unsub
+    }
+
+    let prevBubbleSignature = ''
+    const onBubbleVisibilityChange = () => {
+      const bubbleTerms = syncBubbleDebugTerms()
+      const signature = bubbleTerms.map((term) => `${term.id}:${term.score.toFixed(4)}`).join('|')
+      if (signature === prevBubbleSignature) return
+      prevBubbleSignature = signature
+      if (bubbleTerms.length > 0) pushBubbleLog(bubbleTerms)
+    }
+
+    const unsubTerms = useTermStore.subscribe(onBubbleVisibilityChange)
+    const unsubBubble = useBubbleStore.subscribe(onBubbleVisibilityChange)
+    return () => {
+      unsubTerms()
+      unsubBubble()
+    }
   }, [])
 
   useEffect(() => {
@@ -95,6 +115,10 @@ export const ReferDictScoreSseBridge: React.FC<ReferDictScoreSseBridgeProps> = (
       const store = useTermStore.getState()
       store.addTerms(adapted.toAdd)
       adapted.toUpdate.forEach(({ id, score }) => store.updateTermScore(id, score))
+      const bubbleStore = useBubbleStore.getState()
+      adapted.toAdd.forEach((term) => {
+        bubbleStore.addVisibleTermId(term.id)
+      })
     },
   })
   return null

--- a/Frontend/src/presentation/hooks/useBubbleLifecycle.ts
+++ b/Frontend/src/presentation/hooks/useBubbleLifecycle.ts
@@ -1,70 +1,72 @@
 import { useEffect, useRef } from 'react'
-import { useTermStore } from '../../stores/termStore'
+import { useBubbleStore, computeSoftLimit, SOFT_LIFESPAN_MS } from '../../stores/bubbleStore'
 import { useTermMapWindowSettingsStore } from '../../stores/termMapWindowSettingsStore'
+import { useTermStore } from '../../stores/termStore'
 
 export const LEGACY_SOFT_LIMIT = 20
-export const DEATH_ROW_MS = 5000
+export const DEATH_ROW_MS = SOFT_LIFESPAN_MS
 
 export function useBubbleLifecycle() {
   const deathRowRef = useRef<Record<string, number>>({})
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      const { activeTerms, termTimestamps, pinnedTermIds, removeTermById } = useTermStore.getState()
-      const maxVisibleTerms = useTermMapWindowSettingsStore.getState().maxVisibleTerms
-      const hardLimit = maxVisibleTerms
-      const softLimit = Math.min(LEGACY_SOFT_LIMIT, hardLimit)
+      const hardLimit = useTermMapWindowSettingsStore.getState().maxVisibleTerms
+      const softLimit = computeSoftLimit(hardLimit)
+      const pinnedTermIds = useTermStore.getState().pinnedTermIds
+      const { visibleTermIds, bubbleTimestamps, removeVisibleTermId } = useBubbleStore.getState()
       const deathRow = deathRowRef.current
       const now = Date.now()
 
-      if (activeTerms.length <= softLimit) {
+      if (visibleTermIds.length <= softLimit) {
         deathRowRef.current = {}
         return
       }
 
-      const sorted = [...activeTerms].sort(
-        (a, b) => (termTimestamps[a.id] ?? 0) - (termTimestamps[b.id] ?? 0),
+      const sorted = [...visibleTermIds].sort(
+        (a, b) => (bubbleTimestamps[a] ?? 0) - (bubbleTimestamps[b] ?? 0),
       )
 
       if (sorted.length > hardLimit) {
         let overflowCount = sorted.length - hardLimit
-        for (const term of sorted) {
+        for (const termId of sorted) {
           if (overflowCount <= 0) break
-          if (pinnedTermIds.has(term.id)) continue
-          removeTermById(term.id)
-          delete deathRow[term.id]
+          if (pinnedTermIds.has(termId)) continue
+          removeVisibleTermId(termId)
+          delete deathRow[termId]
           overflowCount -= 1
         }
       }
 
-      const refreshedActiveTerms = useTermStore.getState().activeTerms
-      if (refreshedActiveTerms.length <= softLimit) {
+      const refreshedVisible = useBubbleStore.getState().visibleTermIds
+      const refreshedTimestamps = useBubbleStore.getState().bubbleTimestamps
+      if (refreshedVisible.length <= softLimit) {
         deathRowRef.current = {}
         return
       }
 
-      const refreshedSorted = [...refreshedActiveTerms].sort(
-        (a, b) => (termTimestamps[a.id] ?? 0) - (termTimestamps[b.id] ?? 0),
+      const refreshedSorted = [...refreshedVisible].sort(
+        (a, b) => (refreshedTimestamps[a] ?? 0) - (refreshedTimestamps[b] ?? 0),
       )
       const candidateCount = refreshedSorted.length - softLimit
       const deathCandidates = refreshedSorted
-        .filter((term) => !pinnedTermIds.has(term.id))
+        .filter((termId) => !pinnedTermIds.has(termId))
         .slice(0, candidateCount)
-      const candidateIds = new Set(deathCandidates.map((term) => term.id))
-      const survivors = refreshedSorted.filter((term) => !candidateIds.has(term.id))
+      const candidateIds = new Set(deathCandidates)
+      const survivors = refreshedSorted.filter((termId) => !candidateIds.has(termId))
 
-      survivors.forEach((term) => {
-        delete deathRow[term.id]
+      survivors.forEach((termId) => {
+        delete deathRow[termId]
       })
 
-      deathCandidates.forEach((term) => {
-        if (deathRow[term.id] == null) {
-          deathRow[term.id] = now
+      deathCandidates.forEach((termId) => {
+        if (deathRow[termId] == null) {
+          deathRow[termId] = now
           return
         }
-        if (now - deathRow[term.id] >= DEATH_ROW_MS) {
-          removeTermById(term.id)
-          delete deathRow[term.id]
+        if (now - deathRow[termId] >= DEATH_ROW_MS) {
+          removeVisibleTermId(termId)
+          delete deathRow[termId]
         }
       })
     }, 1000)

--- a/Frontend/src/presentation/hooks/useDemoImportantTermsSync.ts
+++ b/Frontend/src/presentation/hooks/useDemoImportantTermsSync.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useTranscriptStore } from '../../stores/transcriptStore'
 import { useDemoImportantMarkingStore } from '../../stores/demoImportantMarkingStore'
 import { useTermStore } from '../../stores/termStore'
+import { useBubbleStore } from '../../stores/bubbleStore'
 import { findMockImportantTermsInText } from '../../debug/demo/mockImportantTerms'
 
 /**
@@ -17,6 +18,12 @@ export function useDemoImportantTermsSync(): void {
     stripDemoImportantTerms()
     if (!enabled || !transcript.trim()) return
     const found = findMockImportantTermsInText(transcript)
-    if (found.length > 0) addTerms(found)
+    if (found.length > 0) {
+      addTerms(found)
+      const bubbleStore = useBubbleStore.getState()
+      found.forEach((term) => {
+        bubbleStore.addVisibleTermId(term.id)
+      })
+    }
   }, [transcript, enabled])
 }

--- a/Frontend/src/presentation/windows/BubbleCloudWindow/index.tsx
+++ b/Frontend/src/presentation/windows/BubbleCloudWindow/index.tsx
@@ -1,12 +1,20 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { BubbleCloud } from '../../../app/components/BubbleCloud'
 import { useTermStore } from '../../../stores/termStore'
+import { useBubbleStore } from '../../../stores/bubbleStore'
 import type { WindowProps } from '../IWindowDefinition'
 import type { Term } from '../../../domain/entities/Term'
 import { useScoreUpdate } from '../../hooks/useScoreUpdate'
 
 export const BubbleCloudWindow: React.FC<WindowProps> = ({ darkMode = true }) => {
   const activeTerms = useTermStore(s => s.activeTerms)
+  const visibleTermIds = useBubbleStore(s => s.visibleTermIds)
+  const bubbleTerms = useMemo(
+    () => visibleTermIds
+      .map((id) => activeTerms.find((term) => term.id === id))
+      .filter((term): term is Term => term != null),
+    [activeTerms, visibleTermIds],
+  )
   const isPinned = useTermStore(s => s.pinnedTermIds)
   const selectTerm = useTermStore(s => s.selectTerm)
   const addToHistory = useTermStore(s => s.addToHistory)
@@ -21,7 +29,7 @@ export const BubbleCloudWindow: React.FC<WindowProps> = ({ darkMode = true }) =>
 
   return (
     <BubbleCloud
-      activeTerms={activeTerms as any}
+      activeTerms={bubbleTerms as any}
       onTermClick={handleTermClick}
       darkMode={darkMode}
       isPinned={isPinned}

--- a/Frontend/src/stores/__tests__/bubbleStore.test.ts
+++ b/Frontend/src/stores/__tests__/bubbleStore.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { useBubbleStore } from '../bubbleStore'
+import { useTermStore } from '../termStore'
+import { useTermMapWindowSettingsStore } from '../termMapWindowSettingsStore'
+
+describe('bubbleStore', () => {
+  beforeEach(() => {
+    useTermMapWindowSettingsStore.setState({
+      masterSizeScale: 1,
+      bubbleSizeScale: 1,
+      textFontSizePx: 12,
+      autoSwitchEnabled: false,
+      autoSwitchIntervalSec: 4,
+      maxVisibleTerms: 5,
+    })
+    useTermStore.setState({
+      activeTerms: [],
+      termTimestamps: {},
+      selectedTerm: null,
+      searchHistory: [],
+      pinnedTermIds: new Set(),
+    })
+    useBubbleStore.setState({
+      visibleTermIds: [],
+      bubbleTimestamps: {},
+    })
+  })
+
+  it('表示枠に termId を追加できる', () => {
+    expect(useBubbleStore.getState().addVisibleTermId('a')).toBe(true)
+    expect(useBubbleStore.getState().visibleTermIds).toEqual(['a'])
+    expect(typeof useBubbleStore.getState().bubbleTimestamps['a']).toBe('number')
+  })
+
+  it('上限到達時は最古の非スター語を表示枠から入れ替える', () => {
+    const add = useBubbleStore.getState().addVisibleTermId
+    add('a')
+    add('b')
+    add('c')
+    add('d')
+    add('e')
+    expect(add('f')).toBe(true)
+    expect(useBubbleStore.getState().visibleTermIds).toEqual(['b', 'c', 'd', 'e', 'f'])
+  })
+
+  it('表示枠がスターで埋まっている場合は新規を表示枠に追加しない', () => {
+    const add = useBubbleStore.getState().addVisibleTermId
+    for (const id of ['p1', 'p2', 'p3', 'p4', 'p5']) {
+      add(id)
+      useTermStore.getState().togglePin(id)
+    }
+    expect(add('extra')).toBe(false)
+    expect(useBubbleStore.getState().visibleTermIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5'])
+  })
+
+  it('スター語は残して非スター語を優先的に表示枠から入れ替える', () => {
+    const add = useBubbleStore.getState().addVisibleTermId
+    add('a')
+    add('b')
+    add('c')
+    add('d')
+    add('e')
+    useTermStore.getState().togglePin('a')
+    expect(add('f')).toBe(true)
+    expect(useBubbleStore.getState().visibleTermIds).toEqual(['a', 'c', 'd', 'e', 'f'])
+  })
+
+  it('removeVisibleTermId で表示枠とタイムスタンプを削除する', () => {
+    useBubbleStore.getState().addVisibleTermId('a')
+    useBubbleStore.getState().addVisibleTermId('b')
+    useBubbleStore.getState().removeVisibleTermId('a')
+    const s = useBubbleStore.getState()
+    expect(s.visibleTermIds).toEqual(['b'])
+    expect(s.bubbleTimestamps['a']).toBeUndefined()
+  })
+
+  it('clearVisible で表示枠を空にする', () => {
+    useBubbleStore.getState().addVisibleTermId('a')
+    useBubbleStore.getState().clearVisible()
+    const s = useBubbleStore.getState()
+    expect(s.visibleTermIds).toHaveLength(0)
+    expect(Object.keys(s.bubbleTimestamps)).toHaveLength(0)
+  })
+})

--- a/Frontend/src/stores/__tests__/termStore.test.ts
+++ b/Frontend/src/stores/__tests__/termStore.test.ts
@@ -57,7 +57,7 @@ describe('termStore', () => {
     expect(Object.keys(state.termTimestamps)).toHaveLength(1)
   })
 
-  it('maxVisibleTerms 上限到達時は最古の非スター語を入れ替える', () => {
+  it('maxVisibleTerms 超過でも辞書からは追い出さない', () => {
     useTermMapWindowSettingsStore.getState().setMaxVisibleTerms(5)
     useTermStore.getState().addTerms([
       makeTerm('a'),
@@ -67,10 +67,12 @@ describe('termStore', () => {
       makeTerm('e'),
     ])
     useTermStore.getState().addTerms([makeTerm('f')])
-    expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual(['b', 'c', 'd', 'e', 'f'])
+    expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual([
+      'a', 'b', 'c', 'd', 'e', 'f',
+    ])
   })
 
-  it('表示枠がスターで埋まっている場合は新規追加しない', () => {
+  it('スター枠満杯でも辞書には新規語を追加する', () => {
     useTermMapWindowSettingsStore.getState().setMaxVisibleTerms(5)
     useTermStore.getState().addTerms([
       makeTerm('p1'),
@@ -83,21 +85,9 @@ describe('termStore', () => {
       useTermStore.getState().togglePin(id)
     }
     useTermStore.getState().addTerms([makeTerm('extra')])
-    expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual(['p1', 'p2', 'p3', 'p4', 'p5'])
-  })
-
-  it('スター語は残して非スター語を優先的に置き換える', () => {
-    useTermMapWindowSettingsStore.getState().setMaxVisibleTerms(5)
-    useTermStore.getState().addTerms([
-      makeTerm('a'),
-      makeTerm('b'),
-      makeTerm('c'),
-      makeTerm('d'),
-      makeTerm('e'),
+    expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual([
+      'p1', 'p2', 'p3', 'p4', 'p5', 'extra',
     ])
-    useTermStore.getState().togglePin('a')
-    useTermStore.getState().addTerms([makeTerm('f')])
-    expect(useTermStore.getState().activeTerms.map((term) => term.id)).toEqual(['a', 'c', 'd', 'e', 'f'])
   })
 
   it('updateTermScore で対象のスコアを更新できる', () => {

--- a/Frontend/src/stores/bubbleStore.ts
+++ b/Frontend/src/stores/bubbleStore.ts
@@ -1,75 +1,79 @@
 import { create } from 'zustand'
-import type { Bubble } from '../domain/entities/Bubble'
+import { useTermMapWindowSettingsStore } from './termMapWindowSettingsStore'
+import { useTermStore } from './termStore'
 
-const MAX_BUBBLES = 30
-const SOFT_LIMIT = 20
-const SOFT_LIFESPAN_MS = 5000
+export const LEGACY_SOFT_LIMIT = 20
+export const SOFT_LIFESPAN_MS = 5000
 
-interface BubbleState {
-  bubbles: Bubble[]
-  bubbleTimestamps: Record<string, number>
-
-  upsertBubble: (bubble: Bubble) => void
-  removeBubbleByTermId: (termId: string) => void
-  pruneExpired: () => void
-  clearBubbles: () => void
+export function computeSoftLimit(hardLimit: number): number {
+  return Math.min(LEGACY_SOFT_LIMIT, hardLimit)
 }
 
-export const useBubbleStore = create<BubbleState>((set) => ({
-  bubbles: [],
+function findOldestRemovableVisibleId(
+  visibleTermIds: string[],
+  bubbleTimestamps: Record<string, number>,
+  pinnedTermIds: Set<string>,
+): string | null {
+  let oldestId: string | null = null
+  let oldestTs = Number.POSITIVE_INFINITY
+  for (const id of visibleTermIds) {
+    if (pinnedTermIds.has(id)) continue
+    const ts = bubbleTimestamps[id] ?? 0
+    if (ts < oldestTs) {
+      oldestTs = ts
+      oldestId = id
+    }
+  }
+  return oldestId
+}
+
+interface BubbleState {
+  visibleTermIds: string[]
+  bubbleTimestamps: Record<string, number>
+
+  /** 表示枠へ追加。スター枠満杯などで入れられない場合は false */
+  addVisibleTermId: (termId: string) => boolean
+  removeVisibleTermId: (termId: string) => void
+  clearVisible: () => void
+}
+
+export const useBubbleStore = create<BubbleState>((set, get) => ({
+  visibleTermIds: [],
   bubbleTimestamps: {},
 
-  upsertBubble: (bubble) => set((state) => {
-    const exists = state.bubbles.some(b => b.term.id === bubble.term.id)
-    const now = Date.now()
+  addVisibleTermId: (termId) => {
+    const hardLimit = useTermMapWindowSettingsStore.getState().maxVisibleTerms
+    const pinnedTermIds = useTermStore.getState().pinnedTermIds
+    const state = get()
+    if (state.visibleTermIds.includes(termId)) return true
 
-    let bubbles = exists
-      ? state.bubbles.map(b => b.term.id === bubble.term.id ? bubble : b)
-      : [...state.bubbles, bubble]
+    let visibleTermIds = [...state.visibleTermIds]
+    let bubbleTimestamps = { ...state.bubbleTimestamps }
 
-    const timestamps = exists
-      ? state.bubbleTimestamps
-      : { ...state.bubbleTimestamps, [bubble.term.id]: now }
-
-    // 上限超過時は最古のものを削除
-    if (bubbles.length > MAX_BUBBLES) {
-      const oldest = bubbles.reduce((a, b) =>
-        (timestamps[a.term.id] ?? 0) < (timestamps[b.term.id] ?? 0) ? a : b
-      )
-      bubbles = bubbles.filter(b => b.term.id !== oldest.term.id)
-      const { [oldest.term.id]: _, ...rest } = timestamps
-      return { bubbles, bubbleTimestamps: rest }
+    while (visibleTermIds.length >= hardLimit) {
+      const removableId = findOldestRemovableVisibleId(visibleTermIds, bubbleTimestamps, pinnedTermIds)
+      if (!removableId) return false
+      visibleTermIds = visibleTermIds.filter((id) => id !== removableId)
+      const { [removableId]: _, ...rest } = bubbleTimestamps
+      bubbleTimestamps = rest
     }
 
-    return { bubbles, bubbleTimestamps: timestamps }
-  }),
+    const now = Date.now()
+    set({
+      visibleTermIds: [...visibleTermIds, termId],
+      bubbleTimestamps: { ...bubbleTimestamps, [termId]: now },
+    })
+    return true
+  },
 
-  removeBubbleByTermId: (termId) => set((state) => {
+  removeVisibleTermId: (termId) => set((state) => {
+    if (!state.visibleTermIds.includes(termId)) return {}
     const { [termId]: _, ...rest } = state.bubbleTimestamps
     return {
-      bubbles: state.bubbles.filter(b => b.term.id !== termId),
+      visibleTermIds: state.visibleTermIds.filter((id) => id !== termId),
       bubbleTimestamps: rest,
     }
   }),
 
-  pruneExpired: () => set((state) => {
-    if (state.bubbles.length <= SOFT_LIMIT) return {}
-    const now = Date.now()
-    const toRemove = new Set<string>()
-    for (const bubble of state.bubbles) {
-      const addedAt = state.bubbleTimestamps[bubble.term.id] ?? now
-      if (now - addedAt > SOFT_LIFESPAN_MS) {
-        toRemove.add(bubble.term.id)
-      }
-    }
-    if (toRemove.size === 0) return {}
-    const timestamps = { ...state.bubbleTimestamps }
-    toRemove.forEach(id => delete timestamps[id])
-    return {
-      bubbles: state.bubbles.filter(b => !toRemove.has(b.term.id)),
-      bubbleTimestamps: timestamps,
-    }
-  }),
-
-  clearBubbles: () => set({ bubbles: [], bubbleTimestamps: {} }),
+  clearVisible: () => set({ visibleTermIds: [], bubbleTimestamps: {} }),
 }))

--- a/Frontend/src/stores/termStore.ts
+++ b/Frontend/src/stores/termStore.ts
@@ -2,7 +2,6 @@ import { create } from 'zustand'
 import type { Term } from '../domain/entities/Term'
 import { normalizeTermCategory } from '../domain/entities/Term'
 import { DEMO_IMPORTANT_TERM_ID_PREFIX } from '../debug/demo/mockImportantTerms'
-import { useTermMapWindowSettingsStore } from './termMapWindowSettingsStore'
 
 interface TermState {
   activeTerms: Term[]
@@ -34,41 +33,12 @@ export const useTermStore = create<TermState>((set) => ({
 
   addTerms: (terms) => set((state) => {
     const now = Date.now()
-    const maxVisibleTerms = useTermMapWindowSettingsStore.getState().maxVisibleTerms
     const existingIds = new Set(state.activeTerms.map((term) => term.id))
     const nextActiveTerms = [...state.activeTerms]
     const nextTermTimestamps = { ...state.termTimestamps }
 
-    const findOldestRemovableId = (): string | null => {
-      let oldestId: string | null = null
-      let oldestTs = Number.POSITIVE_INFINITY
-      for (const term of nextActiveTerms) {
-        if (state.pinnedTermIds.has(term.id)) continue
-        const ts = nextTermTimestamps[term.id] ?? 0
-        if (ts < oldestTs) {
-          oldestTs = ts
-          oldestId = term.id
-        }
-      }
-      return oldestId
-    }
-
     for (const t of terms) {
       if (existingIds.has(t.id)) continue
-
-      while (nextActiveTerms.length >= maxVisibleTerms) {
-        const removableId = findOldestRemovableId()
-        if (!removableId) {
-          return {
-            activeTerms: nextActiveTerms,
-            termTimestamps: nextTermTimestamps,
-          }
-        }
-        const removeIdx = nextActiveTerms.findIndex((term) => term.id === removableId)
-        if (removeIdx >= 0) nextActiveTerms.splice(removeIdx, 1)
-        delete nextTermTimestamps[removableId]
-        existingIds.delete(removableId)
-      }
 
       const normalized: Term = {
         ...t,


### PR DESCRIPTION
## Summary

- `termStore.activeTerms` をセッション辞書として扱い、ライフタイム・上限による削除をやめる
- `bubbleStore.visibleTermIds` でバブル表示枠のみ管理（`maxVisibleTerms`・5秒猶予・溢れ削除）
- スター枠満杯時は辞書に登録し、バブル表示だけ抑止する
- `useBubbleLifecycle` は `removeVisibleTermId` のみ使用し、ランキング・文字起こしから語が消えないようにする

## コミット構成（10件）

1. `docs(orders)`: order-013 設計記録
2. `refactor(stores)`: bubbleStore 表示枠 ID 管理
3. `fix(stores)`: termStore 辞書追い出し廃止
4. `refactor(hooks)`: useBubbleLifecycle
5. `feat(windows)`: BubbleCloudWindow フィルタ
6. `feat(sse)`: ReferDictScoreSseBridge 配線
7. `chore(frontend)`: clearVisible / デモ同期
8. `test(stores)`: bubbleStore 単体
9. `test(stores)`: termStore 期待値更新
10. `docs(test)`: test-spec-025

## Test plan

- [ ] SSE で語数が増えてもランキング・文字起こしの件数はバブル上限で減らない
- [ ] 全スター時に新規語がランキングに載りバブルに出ない
- [ ] グローバルリセットで辞書と表示枠が空になる
- [x] `bun test src/stores/__tests__/bubbleStore.test.ts src/stores/__tests__/termStore.test.ts`（21件）
- [x] `npm run build`

## 関連

- `Frontend/docs/orders/order-013.md`
- `Frontend/docs/tests/test-spec-025.md`


Made with [Cursor](https://cursor.com)